### PR TITLE
feat: optional video format for screen recordings (fixes #173)

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ No configuration required for this plugin.
 * [`start(...)`](#start)
 * [`stop()`](#stop)
 * [`getPluginVersion()`](#getpluginversion)
+* [Interfaces](#interfaces)
+* [Type Aliases](#type-aliases)
 
 </docgen-index>
 
@@ -116,7 +118,7 @@ Allows you to capture video recordings of the screen with optional audio.
 ### start(...)
 
 ```typescript
-start(options?: { recordAudio?: boolean | undefined; } | undefined) => Promise<void>
+start(options?: StartRecordingOptions | undefined) => Promise<void>
 ```
 
 Start recording the device screen.
@@ -126,9 +128,9 @@ prompted to grant screen recording permissions if not already granted.
 On iOS, the system recording UI will be displayed. On Android, the recording
 starts immediately after permission is granted.
 
-| Param         | Type                                    | Description                       |
-| ------------- | --------------------------------------- | --------------------------------- |
-| **`options`** | <code>{ recordAudio?: boolean; }</code> | - Recording configuration options |
+| Param         | Type                                                                    | Description                       |
+| ------------- | ----------------------------------------------------------------------- | --------------------------------- |
+| **`options`** | <code><a href="#startrecordingoptions">StartRecordingOptions</a></code> | - Recording configuration options |
 
 **Since:** 1.0.0
 
@@ -165,5 +167,28 @@ Get the native Capacitor plugin version.
 **Since:** 1.0.0
 
 --------------------
+
+
+### Interfaces
+
+
+#### StartRecordingOptions
+
+Options for {@link ScreenRecorderPlugin.start}.
+
+| Prop              | Type                                                                                                                | Description                                                                                                                                                                                                         | Default            | Since |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------ | ----- |
+| **`recordAudio`** | <code>boolean</code>                                                                                                | Whether to record audio along with the screen video.                                                                                                                                                                | <code>false</code> | 1.0.0 |
+| **`format`**      | <code><a href="#screenrecordervideoformat">ScreenRecorderVideoFormat</a> \| 'video/mp4' \| 'video/quicktime'</code> | Video container format for the saved recording. Accepts `mp4`, `mov`, or MIME types `video/mp4` and `video/quicktime`. iOS supports both `mp4` and `mov`. Android records MPEG-4 (`.mp4`) regardless of this value. | <code>'mp4'</code> | 8.3.0 |
+
+
+### Type Aliases
+
+
+#### ScreenRecorderVideoFormat
+
+Supported video container formats for screen recordings.
+
+<code>'mp4' | 'mov'</code>
 
 </docgen-api>

--- a/android/src/main/java/ee/forgr/plugin/screenrecorder/CapgoScrCastWithAudio.kt
+++ b/android/src/main/java/ee/forgr/plugin/screenrecorder/CapgoScrCastWithAudio.kt
@@ -33,6 +33,8 @@ class CapgoScrCastWithAudio private constructor(private val activity: ComponentA
     var options: Options = Options()
         private set
 
+    private var fileExtension: String = "mp4"
+
     private var recordingSession: Intent? = null
     private var serviceBinder: CapgoRecorderService? = null
     private var outputFile: File? = null
@@ -94,6 +96,14 @@ class CapgoScrCastWithAudio private constructor(private val activity: ComponentA
         this.options = handleDynamicVideoSize(options)
     }
 
+    fun updateVideoFormat(format: String?) {
+        val resolved = VideoFormatResolver.resolve(format)
+        fileExtension = resolved.extension
+        options = handleDynamicVideoSize(
+            options.copy(storage = options.storage.copy(outputFormat = resolved.outputFormat)),
+        )
+    }
+
     fun record() {
         Dexter.withContext(activity)
             .withPermissions(
@@ -111,7 +121,7 @@ class CapgoScrCastWithAudio private constructor(private val activity: ComponentA
 
     private fun resolveOutputFile(): File? {
         val dir = options.storage.mediaStorageLocation ?: return null
-        return File("${dir.path}${File.separator}${options.storage.fileNameFormatter()}.mp4")
+        return File("${dir.path}${File.separator}${options.storage.fileNameFormatter()}.$fileExtension")
     }
 
     private fun startService(result: ActivityResult, file: File) {

--- a/android/src/main/java/ee/forgr/plugin/screenrecorder/ScreenRecorderPlugin.java
+++ b/android/src/main/java/ee/forgr/plugin/screenrecorder/ScreenRecorderPlugin.java
@@ -30,7 +30,12 @@ public class ScreenRecorderPlugin extends Plugin {
     public void start(PluginCall call) {
         try {
             final boolean recordAudio = call.getBoolean("recordAudio", false);
+            final String format = call.getString("format");
             recordingWithAudio = recordAudio;
+
+            final Options configuredOptions = VideoFormatResolver.INSTANCE.applyTo(recorder.getOptions(), format);
+            recorder.updateOptions(configuredOptions);
+            audioRecorder.updateVideoFormat(format);
 
             if (recordAudio) {
                 audioRecorder.record();

--- a/android/src/main/java/ee/forgr/plugin/screenrecorder/VideoFormatResolver.kt
+++ b/android/src/main/java/ee/forgr/plugin/screenrecorder/VideoFormatResolver.kt
@@ -5,29 +5,17 @@ import dev.bmcreations.scrcast.config.Options
 
 object VideoFormatResolver {
     data class Resolved(
-        val extension: String,
-        val outputFormat: Int,
+        val extension: String = "mp4",
+        val outputFormat: Int = MediaRecorder.OutputFormat.MPEG_4,
     )
 
-    fun resolve(format: String?): Resolved {
-        return when (normalize(format)) {
-            "mov", "video/quicktime", "quicktime" -> Resolved(
-                extension = "mp4",
-                outputFormat = MediaRecorder.OutputFormat.MPEG_4,
-            )
-            else -> Resolved(
-                extension = "mp4",
-                outputFormat = MediaRecorder.OutputFormat.MPEG_4,
-            )
-        }
+    fun resolve(@Suppress("UNUSED_PARAMETER") format: String?): Resolved {
+        // Android MediaRecorder only supports MPEG-4 output.
+        return Resolved()
     }
 
     fun applyTo(options: Options, format: String?): Options {
         val resolved = resolve(format)
         return options.copy(storage = options.storage.copy(outputFormat = resolved.outputFormat))
-    }
-
-    private fun normalize(format: String?): String? {
-        return format?.trim()?.lowercase()
     }
 }

--- a/android/src/main/java/ee/forgr/plugin/screenrecorder/VideoFormatResolver.kt
+++ b/android/src/main/java/ee/forgr/plugin/screenrecorder/VideoFormatResolver.kt
@@ -1,0 +1,33 @@
+package ee.forgr.plugin.screenrecorder
+
+import android.media.MediaRecorder
+import dev.bmcreations.scrcast.config.Options
+
+object VideoFormatResolver {
+    data class Resolved(
+        val extension: String,
+        val outputFormat: Int,
+    )
+
+    fun resolve(format: String?): Resolved {
+        return when (normalize(format)) {
+            "mov", "video/quicktime", "quicktime" -> Resolved(
+                extension = "mp4",
+                outputFormat = MediaRecorder.OutputFormat.MPEG_4,
+            )
+            else -> Resolved(
+                extension = "mp4",
+                outputFormat = MediaRecorder.OutputFormat.MPEG_4,
+            )
+        }
+    }
+
+    fun applyTo(options: Options, format: String?): Options {
+        val resolved = resolve(format)
+        return options.copy(storage = options.storage.copy(outputFormat = resolved.outputFormat))
+    }
+
+    private fun normalize(format: String?): String? {
+        return format?.trim()?.lowercase()
+    }
+}

--- a/ios/Sources/ScreenRecorderPlugin/ScreenRecorderPlugin.swift
+++ b/ios/Sources/ScreenRecorderPlugin/ScreenRecorderPlugin.swift
@@ -19,7 +19,8 @@ public class ScreenRecorderPlugin: CAPPlugin, CAPBridgedPlugin {
 
     @objc func start(_ call: CAPPluginCall) {
         let recordAudio = call.getBool("recordAudio") ?? false
-        implementation.startRecording(saveToCameraRoll: true, recordAudio: recordAudio, handler: { error in
+        let videoFormat = VideoContainerFormat.from(call.getString("format"))
+        implementation.startRecording(saveToCameraRoll: true, recordAudio: recordAudio, videoFormat: videoFormat, handler: { error in
             if let error = error {
                 debugPrint("Error when start recording \(error)")
                 call.reject("Cannot start recording")
@@ -28,6 +29,7 @@ public class ScreenRecorderPlugin: CAPPlugin, CAPBridgedPlugin {
             }
         })
     }
+
     @objc func stop(_ call: CAPPluginCall) {
         implementation.stoprecording(handler: { error in
             if let error = error {
@@ -42,5 +44,4 @@ public class ScreenRecorderPlugin: CAPPlugin, CAPBridgedPlugin {
     @objc func getPluginVersion(_ call: CAPPluginCall) {
         call.resolve(["version": self.pluginVersion])
     }
-
 }

--- a/ios/Sources/ScreenRecorderPlugin/Wyler.swift
+++ b/ios/Sources/ScreenRecorderPlugin/Wyler.swift
@@ -17,6 +17,38 @@ public enum ScreenRecorderError: Error {
     case photoLibraryAccessNotGranted
 }
 
+public enum VideoContainerFormat {
+    case mp4
+    case mov
+
+    var fileType: AVFileType {
+        switch self {
+        case .mp4:
+            return .mp4
+        case .mov:
+            return .mov
+        }
+    }
+
+    var fileExtension: String {
+        switch self {
+        case .mp4:
+            return "mp4"
+        case .mov:
+            return "mov"
+        }
+    }
+
+    static func from(_ value: String?) -> VideoContainerFormat {
+        switch value?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+        case "mov", "video/quicktime", "quicktime":
+            return .mov
+        default:
+            return .mp4
+        }
+    }
+}
+
 public final class ScreenRecorder {
     private var videoOutputURL: URL?
     private var videoWriter: AVAssetWriter?
@@ -25,15 +57,18 @@ public final class ScreenRecorder {
     private var appAudioWriterInput: AVAssetWriterInput?
     private var saveToCameraRoll = false
     private var recordAudio = false
+    private var videoFormat: VideoContainerFormat = .mp4
     let recorder = RPScreenRecorder.shared()
 
     public func startRecording(to outputURL: URL? = nil,
                                size: CGSize? = nil,
                                saveToCameraRoll: Bool = false,
                                recordAudio: Bool = false,
+                               videoFormat: VideoContainerFormat = .mp4,
                                handler: @escaping (Error?) -> Void) {
         self.saveToCameraRoll = saveToCameraRoll
         self.recordAudio = recordAudio
+        self.videoFormat = videoFormat
         resetWriterState()
 
         recorder.isMicrophoneEnabled = recordAudio
@@ -75,7 +110,8 @@ public final class ScreenRecorder {
             newVideoOutputURL = passedVideoOutput
         } else {
             let documentsPath = NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true)[0] as NSString
-            newVideoOutputURL = URL(fileURLWithPath: documentsPath.appendingPathComponent("WylerNewVideo.mp4"))
+            let fileName = "WylerNewVideo.\(videoFormat.fileExtension)"
+            newVideoOutputURL = URL(fileURLWithPath: documentsPath.appendingPathComponent(fileName))
             self.videoOutputURL = newVideoOutputURL
         }
 
@@ -84,7 +120,7 @@ public final class ScreenRecorder {
         } catch {}
 
         do {
-            try videoWriter = AVAssetWriter(outputURL: newVideoOutputURL, fileType: AVFileType.mp4)
+            try videoWriter = AVAssetWriter(outputURL: newVideoOutputURL, fileType: videoFormat.fileType)
         } catch let writerError as NSError {
             videoWriter = nil
             throw writerError

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -1,4 +1,38 @@
 /**
+ * Supported video container formats for screen recordings.
+ *
+ * @since 8.3.0
+ */
+export type ScreenRecorderVideoFormat = 'mp4' | 'mov';
+
+/**
+ * Options for {@link ScreenRecorderPlugin.start}.
+ *
+ * @since 8.3.0
+ */
+export interface StartRecordingOptions {
+  /**
+   * Whether to record audio along with the screen video.
+   *
+   * @default false
+   * @since 1.0.0
+   */
+  recordAudio?: boolean;
+
+  /**
+   * Video container format for the saved recording.
+   *
+   * Accepts `mp4`, `mov`, or MIME types `video/mp4` and `video/quicktime`.
+   * iOS supports both `mp4` and `mov`. Android records MPEG-4 (`.mp4`) regardless of this value.
+   *
+   * @default 'mp4'
+   * @since 8.3.0
+   * @example 'mov'
+   */
+  format?: ScreenRecorderVideoFormat | 'video/mp4' | 'video/quicktime';
+}
+
+/**
  * Capacitor Screen Recorder Plugin for recording the device screen.
  * Allows you to capture video recordings of the screen with optional audio.
  *
@@ -15,6 +49,7 @@ export interface ScreenRecorderPlugin {
    *
    * @param options - Recording configuration options
    * @param options.recordAudio - Whether to record audio along with the screen video. Defaults to false.
+   * @param options.format - Video container format for the saved recording. Defaults to `mp4`.
    * @returns Promise that resolves when recording starts
    * @throws Error if recording fails to start or permissions are denied
    * @since 1.0.0
@@ -25,9 +60,12 @@ export interface ScreenRecorderPlugin {
    *
    * // Start recording with audio
    * await ScreenRecorder.start({ recordAudio: true });
+   *
+   * // Start recording as MOV on iOS
+   * await ScreenRecorder.start({ format: 'mov' });
    * ```
    */
-  start(options?: { recordAudio?: boolean }): Promise<void>;
+  start(options?: StartRecordingOptions): Promise<void>;
 
   /**
    * Stop the current screen recording.

--- a/src/web.ts
+++ b/src/web.ts
@@ -1,9 +1,9 @@
 import { WebPlugin } from '@capacitor/core';
 
-import type { ScreenRecorderPlugin } from './definitions';
+import type { ScreenRecorderPlugin, StartRecordingOptions } from './definitions';
 
 export class ScreenRecorderWeb extends WebPlugin implements ScreenRecorderPlugin {
-  async start(): Promise<void> {
+  async start(_options?: StartRecordingOptions): Promise<void> {
     throw new Error('Method not implemented.');
   }
   async stop(): Promise<void> {


### PR DESCRIPTION
## Summary
- Adds optional `format` parameter to `ScreenRecorder.start()` (`mp4`, `mov`, `video/mp4`, `video/quicktime`)
- iOS writes recordings with `AVFileType.mp4` or `AVFileType.mov` based on the selected format
- Android keeps MPEG-4 output (`.mp4`) via `MediaRecorder`; format is accepted for API parity

Fixes #173

## Test plan
- [x] `bun run docgen`
- [x] `bun run verify` (iOS, Android, web)
- [ ] Manual iOS test: `await ScreenRecorder.start({ format: 'mov' })` and confirm saved video plays without glitching
- [ ] Manual Android test: confirm recording still saves as `.mp4`


Made with [Cursor](https://cursor.com)