### PR TITLE
fix(android): handle MediaRecorder prepare failures on screen recording start

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -45,6 +45,9 @@ android {
         sourceCompatibility JavaVersion.VERSION_21
         targetCompatibility JavaVersion.VERSION_21
     }
+    testOptions {
+        unitTests.returnDefaultValues = true
+    }
 }
 
 kotlin {
@@ -63,6 +66,7 @@ dependencies {
     implementation project(':capacitor-android')
     implementation "androidx.appcompat:appcompat:$androidxAppCompatVersion"
     testImplementation "junit:junit:$junitVersion"
+    testImplementation "org.mockito:mockito-core:5.14.2"
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"
     androidTestImplementation "androidx.test.espresso:espresso-core:$androidxEspressoCoreVersion"
     implementation "androidx.core:core-ktx:$androidxCoreVersion"

--- a/android/src/main/java/ee/forgr/plugin/screenrecorder/CapgoScrCast.kt
+++ b/android/src/main/java/ee/forgr/plugin/screenrecorder/CapgoScrCast.kt
@@ -25,19 +25,21 @@ import dev.bmcreations.scrcast.internal.recorder.EXTRA_ERROR
 import dev.bmcreations.scrcast.internal.recorder.STATE_IDLE
 import dev.bmcreations.scrcast.internal.recorder.STATE_RECORDING
 import dev.bmcreations.scrcast.internal.recorder.notification.RecorderNotificationProvider
-import dev.bmcreations.scrcast.recorder.RecordingState
 import ee.forgr.plugin.screenrecorder.service.CapgoRecorderService
 import java.io.File
 
-class CapgoScrCastWithAudio private constructor(private val activity: ComponentActivity) {
+class CapgoScrCast private constructor(
+    private val activity: ComponentActivity,
+    private val recordAudio: Boolean,
+) {
     var options: Options = Options()
         private set
 
     private var fileExtension: String = "mp4"
-
     private var recordingSession: Intent? = null
     private var serviceBinder: CapgoRecorderService? = null
     private var outputFile: File? = null
+    private var startListener: StartListener? = null
 
     private val metrics by lazy {
         DisplayMetrics().apply { activity.windowManager.defaultDisplay.getMetrics(this) }
@@ -65,15 +67,30 @@ class CapgoScrCastWithAudio private constructor(private val activity: ComponentA
 
     private val recordingStateHandler = object : android.content.BroadcastReceiver() {
         override fun onReceive(context: Context?, intent: Intent?) {
-            if (intent?.action == STATE_IDLE) {
-                cleanupSession()
+            when (intent?.action) {
+                STATE_RECORDING -> {
+                    startListener?.onStarted()
+                    startListener = null
+                }
+                STATE_IDLE -> {
+                    val error = intent.getSerializableExtra(EXTRA_ERROR) as? Throwable
+                    if (error != null) {
+                        startListener?.onFailed(error)
+                    }
+                    cleanupSession()
+                }
             }
         }
     }
 
     private val permissionListener = object : MultiplePermissionsListener {
         override fun onPermissionsChecked(report: MultiplePermissionsReport?) {
-            startProjection.launch(Unit)
+            if (report?.areAllPermissionsGranted() == true) {
+                startProjection.launch(Unit)
+            } else {
+                startListener?.onFailed(SecurityException("Required permissions were not granted"))
+                startListener = null
+            }
         }
 
         override fun onPermissionRationaleShouldBeShown(
@@ -86,37 +103,50 @@ class CapgoScrCastWithAudio private constructor(private val activity: ComponentA
 
     private val startProjection = activity.registerForActivityResult(CapgoRecordScreen()) { result ->
         if (result.resultCode != Activity.RESULT_OK) {
+            startListener?.onFailed(IllegalStateException("Screen capture permission denied"))
             return@registerForActivityResult
         }
-        val file = resolveOutputFile() ?: return@registerForActivityResult
+        val file = resolveOutputFile()
+        if (file == null) {
+            startListener?.onFailed(IllegalStateException("Could not resolve screen recording output file"))
+            return@registerForActivityResult
+        }
         startService(result, file)
     }
 
     fun updateOptions(options: Options) {
-        this.options = handleDynamicVideoSize(options)
+        this.options = resolveVideoSize(options)
     }
 
     fun updateVideoFormat(format: String?) {
         val resolved = VideoFormatResolver.resolve(format)
         fileExtension = resolved.extension
-        options = handleDynamicVideoSize(
+        options = resolveVideoSize(
             options.copy(storage = options.storage.copy(outputFormat = resolved.outputFormat)),
         )
     }
 
-    fun record() {
+    fun record(listener: StartListener) {
+        startListener = listener
+        val permissions = buildList {
+            add(Manifest.permission.WRITE_EXTERNAL_STORAGE)
+            add(Manifest.permission.READ_EXTERNAL_STORAGE)
+            if (recordAudio) {
+                add(Manifest.permission.RECORD_AUDIO)
+            }
+        }
         Dexter.withContext(activity)
-            .withPermissions(
-                Manifest.permission.WRITE_EXTERNAL_STORAGE,
-                Manifest.permission.READ_EXTERNAL_STORAGE,
-                Manifest.permission.RECORD_AUDIO,
-            )
+            .withPermissions(permissions)
             .withListener(permissionListener)
             .check()
     }
 
     fun stopRecording() {
         broadcaster.sendBroadcast(Intent(Action.Stop.name))
+    }
+
+    private fun resolveVideoSize(options: Options): Options {
+        return VideoSizeResolver.applyTo(options, metrics.widthPixels, metrics.heightPixels)
     }
 
     private fun resolveOutputFile(): File? {
@@ -133,6 +163,7 @@ class CapgoScrCastWithAudio private constructor(private val activity: ComponentA
             putExtra("outputFile", file.absolutePath)
             putExtra("dpi", dpi)
             putExtra("rotation", activity.windowManager.defaultDisplay.rotation)
+            putExtra("recordAudio", recordAudio)
         }
         recordingSession = session
 
@@ -149,6 +180,7 @@ class CapgoScrCastWithAudio private constructor(private val activity: ComponentA
     }
 
     private fun cleanupSession() {
+        startListener = null
         try {
             broadcaster.unregisterReceiver(recordingStateHandler)
         } catch (ignored: Exception) {
@@ -172,21 +204,15 @@ class CapgoScrCastWithAudio private constructor(private val activity: ComponentA
         outputFile = null
     }
 
-    private fun handleDynamicVideoSize(options: Options): Options {
-        var reconfig = options
-        if (options.video.width == -1) {
-            reconfig = reconfig.copy(video = reconfig.video.copy(width = metrics.widthPixels))
-        }
-        if (options.video.height == -1) {
-            reconfig = reconfig.copy(video = reconfig.video.copy(height = metrics.heightPixels))
-        }
-        return reconfig
+    interface StartListener {
+        fun onStarted()
+        fun onFailed(error: Throwable)
     }
 
     companion object {
         @JvmStatic
-        fun use(activity: ComponentActivity): CapgoScrCastWithAudio {
-            return CapgoScrCastWithAudio(activity)
+        fun use(activity: ComponentActivity, recordAudio: Boolean): CapgoScrCast {
+            return CapgoScrCast(activity, recordAudio)
         }
     }
 }

--- a/android/src/main/java/ee/forgr/plugin/screenrecorder/MediaRecorderPrepare.kt
+++ b/android/src/main/java/ee/forgr/plugin/screenrecorder/MediaRecorderPrepare.kt
@@ -1,0 +1,14 @@
+package ee.forgr.plugin.screenrecorder
+
+import android.media.MediaRecorder
+
+internal object MediaRecorderPrepare {
+    fun tryPrepare(recorder: MediaRecorder?): Throwable? {
+        return try {
+            recorder?.prepare()
+            null
+        } catch (error: Throwable) {
+            error
+        }
+    }
+}

--- a/android/src/main/java/ee/forgr/plugin/screenrecorder/ScreenRecorderPlugin.java
+++ b/android/src/main/java/ee/forgr/plugin/screenrecorder/ScreenRecorderPlugin.java
@@ -5,7 +5,6 @@ import com.getcapacitor.Plugin;
 import com.getcapacitor.PluginCall;
 import com.getcapacitor.PluginMethod;
 import com.getcapacitor.annotation.CapacitorPlugin;
-import dev.bmcreations.scrcast.ScrCast;
 import dev.bmcreations.scrcast.config.Options;
 
 @CapacitorPlugin(name = "ScreenRecorder")
@@ -13,39 +12,48 @@ public class ScreenRecorderPlugin extends Plugin {
 
     private final String pluginVersion = "8.3.4";
 
-    private ScrCast recorder;
-    private CapgoScrCastWithAudio audioRecorder;
+    private CapgoScrCast videoRecorder;
+    private CapgoScrCast audioRecorder;
     private boolean recordingWithAudio = false;
 
     @Override
     public void load() {
-        recorder = ScrCast.use(this.bridge.getActivity());
-        audioRecorder = CapgoScrCastWithAudio.use(this.bridge.getActivity());
-        Options options = new Options();
-        recorder.updateOptions(options);
+        videoRecorder = CapgoScrCast.use(this.bridge.getActivity(), false);
+        audioRecorder = CapgoScrCast.use(this.bridge.getActivity(), true);
+        final Options options = new Options();
+        videoRecorder.updateOptions(options);
         audioRecorder.updateOptions(options);
     }
 
     @PluginMethod
-    public void start(PluginCall call) {
-        try {
-            final boolean recordAudio = call.getBoolean("recordAudio", false);
-            final String format = call.getString("format");
-            recordingWithAudio = recordAudio;
+    public void start(final PluginCall call) {
+        final boolean recordAudio = call.getBoolean("recordAudio", false);
+        final String format = call.getString("format");
+        recordingWithAudio = recordAudio;
 
-            final Options configuredOptions = VideoFormatResolver.INSTANCE.applyTo(recorder.getOptions(), format);
-            recorder.updateOptions(configuredOptions);
-            audioRecorder.updateVideoFormat(format);
+        final CapgoScrCast recorder = recordAudio ? audioRecorder : videoRecorder;
+        final Options configuredOptions = VideoFormatResolver.INSTANCE.applyTo(recorder.getOptions(), format);
+        recorder.updateOptions(configuredOptions);
+        recorder.updateVideoFormat(format);
 
-            if (recordAudio) {
-                audioRecorder.record();
-            } else {
-                recorder.record();
+        call.setKeepAlive(true);
+        recorder.record(
+            new CapgoScrCast.StartListener() {
+                @Override
+                public void onStarted() {
+                    call.resolve();
+                    call.release(bridge);
+                }
+
+                @Override
+                public void onFailed(final Throwable error) {
+                    recordingWithAudio = false;
+                    final Exception exception = error instanceof Exception ? (Exception) error : new Exception(error);
+                    call.reject("Could not start screen recording", exception);
+                    call.release(bridge);
+                }
             }
-            call.resolve();
-        } catch (final Exception e) {
-            call.reject("Could not start screen recording", e);
-        }
+        );
     }
 
     @PluginMethod
@@ -54,7 +62,7 @@ public class ScreenRecorderPlugin extends Plugin {
             if (recordingWithAudio) {
                 audioRecorder.stopRecording();
             } else {
-                recorder.stopRecording();
+                videoRecorder.stopRecording();
             }
             recordingWithAudio = false;
             call.resolve();

--- a/android/src/main/java/ee/forgr/plugin/screenrecorder/VideoSizeResolver.kt
+++ b/android/src/main/java/ee/forgr/plugin/screenrecorder/VideoSizeResolver.kt
@@ -1,0 +1,31 @@
+package ee.forgr.plugin.screenrecorder
+
+import dev.bmcreations.scrcast.config.Options
+
+object VideoSizeResolver {
+    const val MAX_WIDTH = 1920
+    const val MAX_HEIGHT = 1080
+
+    fun applyTo(options: Options, displayWidth: Int, displayHeight: Int): Options {
+        val resolvedWidth = if (options.video.width == -1) displayWidth else options.video.width
+        val resolvedHeight = if (options.video.height == -1) displayHeight else options.video.height
+        val (width, height) = clamp(resolvedWidth, resolvedHeight)
+        return options.copy(video = options.video.copy(width = width, height = height))
+    }
+
+    fun clamp(width: Int, height: Int): Pair<Int, Int> {
+        var w = makeEven(width.coerceAtLeast(2))
+        var h = makeEven(height.coerceAtLeast(2))
+
+        if (w <= MAX_WIDTH && h <= MAX_HEIGHT) {
+            return w to h
+        }
+
+        val scale = minOf(MAX_WIDTH.toFloat() / w, MAX_HEIGHT.toFloat() / h)
+        w = makeEven((w * scale).toInt().coerceAtLeast(2))
+        h = makeEven((h * scale).toInt().coerceAtLeast(2))
+        return w to h
+    }
+
+    fun makeEven(value: Int): Int = if (value % 2 == 0) value else value - 1
+}

--- a/android/src/main/java/ee/forgr/plugin/screenrecorder/service/CapgoRecorderService.kt
+++ b/android/src/main/java/ee/forgr/plugin/screenrecorder/service/CapgoRecorderService.kt
@@ -23,10 +23,12 @@ import dev.bmcreations.scrcast.internal.recorder.*
 import dev.bmcreations.scrcast.internal.recorder.service.orientations
 import dev.bmcreations.scrcast.recorder.*
 import dev.bmcreations.scrcast.recorder.notification.NotificationProvider
+import ee.forgr.plugin.screenrecorder.MediaRecorderPrepare
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import java.io.File
+import java.io.IOException
 
 class CapgoRecorderService : Service() {
 
@@ -86,6 +88,7 @@ class CapgoRecorderService : Service() {
 
     private var requestCode: Int = -1
     private var requestData: Intent = Intent()
+    private var recordAudio: Boolean = false
 
     private var mediaProjection: MediaProjection? = null
     private var mediaProjectionCallback = MediaProjectionCallback()
@@ -120,13 +123,15 @@ class CapgoRecorderService : Service() {
         }
     }
 
-    private fun createRecorder() {
+    private fun createRecorder(): Boolean {
         Log.d("scrcast", "createRecorder()")
         mediaRecorder = createMediaRecorder().apply {
-            setAudioSource(AudioSource.MIC)
+            if (recordAudio) {
+                setAudioSource(AudioSource.MIC)
+                setAudioEncoder(AudioEncoder.AAC)
+            }
             setVideoSource(VideoSource.SURFACE)
             setOutputFormat(options.storage.outputFormat)
-            setAudioEncoder(AudioEncoder.AAC)
             setOutputFile(outputFile)
             with(options.video) {
                 setVideoSize(width, height)
@@ -167,7 +172,22 @@ class CapgoRecorderService : Service() {
             }
             setOrientationHint(orientation)
         }
-        mediaRecorder?.prepare()
+
+        val prepareError = MediaRecorderPrepare.tryPrepare(mediaRecorder)
+        if (prepareError != null) {
+            Log.e("scrcast", "MediaRecorder prepare failed", prepareError)
+            releaseRecorder()
+            return false
+        }
+        return true
+    }
+
+    private fun releaseRecorder() {
+        runCatching {
+            mediaRecorder?.reset()
+            mediaRecorder?.release()
+        }
+        mediaRecorder = null
     }
 
     fun setNotificationProvider(provider: NotificationProvider) {
@@ -236,7 +256,10 @@ class CapgoRecorderService : Service() {
             }
 
             mediaProjection?.registerCallback(mediaProjectionCallback, Handler())
-            createRecorder()
+            if (!createRecorder()) {
+                stopRecording(IOException("MediaRecorder prepare failed"))
+                return@launch
+            }
             virtualDisplay // touch
             try {
                 mediaRecorder?.start()
@@ -260,12 +283,12 @@ class CapgoRecorderService : Service() {
         mediaProjection = null
 
         _virtualDisplay?.release()
+        _virtualDisplay = null
 
         runCatching {
             mediaRecorder?.stop()
-            mediaRecorder?.reset()
-            mediaRecorder?.release()
         }
+        releaseRecorder()
     }
 
     private inner class MediaProjectionCallback : MediaProjection.Callback() {
@@ -281,6 +304,7 @@ class CapgoRecorderService : Service() {
             rotation = it.getIntExtra("rotation", 0)
             dpi = it.getFloatExtra("dpi", 0f)
             outputFile = it.getStringExtra("outputFile") ?: ""
+            recordAudio = it.getBooleanExtra("recordAudio", false)
 
             startRecording(
                 code = it.getIntExtra("code", -1),

--- a/android/src/test/java/ee/forgr/plugin/screenrecorder/RecorderPrepareTest.kt
+++ b/android/src/test/java/ee/forgr/plugin/screenrecorder/RecorderPrepareTest.kt
@@ -1,0 +1,48 @@
+package ee.forgr.plugin.screenrecorder
+
+import android.media.MediaRecorder
+import java.io.IOException
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.mockito.Mockito.doThrow
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+
+class VideoSizeResolverTest {
+    @Test
+    fun clamp_makesOddDimensionsEven() {
+        val (width, height) = VideoSizeResolver.clamp(801, 601)
+        assertEquals(800, width)
+        assertEquals(600, height)
+    }
+
+    @Test
+    fun clamp_scalesDownTo1080p() {
+        val (width, height) = VideoSizeResolver.clamp(1440, 3200)
+        assertEquals(486, width)
+        assertEquals(1080, height)
+        assertEquals(0, width % 2)
+        assertEquals(0, height % 2)
+    }
+}
+
+class MediaRecorderPrepareTest {
+    @Test
+    fun tryPrepare_returnsNullOnSuccess() {
+        val recorder = mock(MediaRecorder::class.java)
+        assertNull(MediaRecorderPrepare.tryPrepare(recorder))
+        verify(recorder).prepare()
+    }
+
+    @Test
+    fun tryPrepare_returnsIOExceptionWithoutThrowing() {
+        val recorder = mock(MediaRecorder::class.java)
+        val error = IOException("prepare failed")
+        doThrow(error).`when`(recorder).prepare()
+
+        val result = MediaRecorderPrepare.tryPrepare(recorder)
+
+        assertEquals(error, result)
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What
- Catch `MediaRecorder.prepare()` failures in `CapgoRecorderService` and stop recording instead of crashing the app process
- Clamp resolved video width/height to even values and a 1080p-safe maximum before recording starts
- Route both audio and non-audio Android recording through `CapgoScrCast` + `CapgoRecorderService` so prepare failures reject the plugin call
- Add unit tests for video size clamping and prepare-failure handling

## Why
On some Android devices, `MediaRecorder.prepare()` throws `IOException` (for example `prepare failed: -2147483648`) when video dimensions are invalid or too large for the device encoder. The prepare call ran outside the existing `start()` try/catch, so the exception became a FATAL EXCEPTION instead of a handled plugin error.

Fixes #3

## How
- Added `VideoSizeResolver` to resolve auto-sized dimensions and clamp them to even, 1080p-safe values
- Added `MediaRecorderPrepare.tryPrepare()` and used it from `createRecorder()`; on failure the service releases the recorder and calls `stopRecording(error)`
- Replaced the scrcast `RecorderService` path with `CapgoScrCast`, which applies size clamping and reports `STATE_RECORDING` / `STATE_IDLE` back to `ScreenRecorderPlugin`
- `ScreenRecorderPlugin.start()` now keeps the call alive and resolves only after recording starts, or rejects when prepare/permission/start fails

## Testing
- `cd android && ./gradlew test build` (passes locally)
- Added JVM unit tests:
  - `VideoSizeResolverTest` for even-dimension and 1080p clamping
  - `MediaRecorderPrepareTest` for prepare IOException handling via mocked `MediaRecorder`

## Not Tested
- Physical device recording on the originally reported Android 11 handset
- Instrumented end-to-end recording with real `MediaProjection` (requires device/emulator)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b63e61b3-752c-40aa-8dad-8e6d242967e2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b63e61b3-752c-40aa-8dad-8e6d242967e2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capacitor-screen-recorder/pr/221"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790232496&installation_model_id=430928&pr_number=221&repository=Cap-go%2Fcapacitor-screen-recorder&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapacitor-screen-recorder%2Fpull%2F221&signature=6a2b7c574fe32261e57596832e202f4c15bb0938ba25fb64db14e770e9ea2d3e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capacitor-screen-recorder/pull/221?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

