### PR TITLE
fix(android): address PR #221 review feedback

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -45,9 +45,6 @@ android {
         sourceCompatibility JavaVersion.VERSION_21
         targetCompatibility JavaVersion.VERSION_21
     }
-    testOptions {
-        unitTests.returnDefaultValues = true
-    }
 }
 
 kotlin {

--- a/android/src/main/java/ee/forgr/plugin/screenrecorder/CapgoRecordingCoordinator.kt
+++ b/android/src/main/java/ee/forgr/plugin/screenrecorder/CapgoRecordingCoordinator.kt
@@ -1,0 +1,23 @@
+package ee.forgr.plugin.screenrecorder
+
+internal object CapgoRecordingCoordinator {
+    private val lock = Any()
+
+    @Volatile
+    private var active = false
+
+    fun tryAcquire(): Boolean = synchronized(lock) {
+        if (active) {
+            false
+        } else {
+            active = true
+            true
+        }
+    }
+
+    fun release() {
+        synchronized(lock) {
+            active = false
+        }
+    }
+}

--- a/android/src/main/java/ee/forgr/plugin/screenrecorder/CapgoScrCast.kt
+++ b/android/src/main/java/ee/forgr/plugin/screenrecorder/CapgoScrCast.kt
@@ -88,8 +88,7 @@ class CapgoScrCast private constructor(
             if (report?.areAllPermissionsGranted() == true) {
                 startProjection.launch(Unit)
             } else {
-                startListener?.onFailed(SecurityException("Required permissions were not granted"))
-                startListener = null
+                notifyStartFailed(SecurityException("Required permissions were not granted"))
             }
         }
 
@@ -103,12 +102,12 @@ class CapgoScrCast private constructor(
 
     private val startProjection = activity.registerForActivityResult(CapgoRecordScreen()) { result ->
         if (result.resultCode != Activity.RESULT_OK) {
-            startListener?.onFailed(IllegalStateException("Screen capture permission denied"))
+            notifyStartFailed(IllegalStateException("Screen capture permission denied"))
             return@registerForActivityResult
         }
         val file = resolveOutputFile()
         if (file == null) {
-            startListener?.onFailed(IllegalStateException("Could not resolve screen recording output file"))
+            notifyStartFailed(IllegalStateException("Could not resolve screen recording output file"))
             return@registerForActivityResult
         }
         startService(result, file)
@@ -126,7 +125,10 @@ class CapgoScrCast private constructor(
         )
     }
 
-    fun record(listener: StartListener) {
+    fun record(listener: StartListener): Boolean {
+        if (startListener != null) {
+            return false
+        }
         startListener = listener
         val permissions = buildList {
             add(Manifest.permission.WRITE_EXTERNAL_STORAGE)
@@ -139,6 +141,12 @@ class CapgoScrCast private constructor(
             .withPermissions(permissions)
             .withListener(permissionListener)
             .check()
+        return true
+    }
+
+    private fun notifyStartFailed(error: Throwable) {
+        startListener?.onFailed(error)
+        startListener = null
     }
 
     fun stopRecording() {

--- a/android/src/main/java/ee/forgr/plugin/screenrecorder/CapgoScrCast.kt
+++ b/android/src/main/java/ee/forgr/plugin/screenrecorder/CapgoScrCast.kt
@@ -40,6 +40,7 @@ class CapgoScrCast private constructor(
     private var serviceBinder: CapgoRecorderService? = null
     private var outputFile: File? = null
     private var startListener: StartListener? = null
+    private var receiverRegistered = false
 
     private val metrics by lazy {
         DisplayMetrics().apply { activity.windowManager.defaultDisplay.getMetrics(this) }
@@ -126,7 +127,7 @@ class CapgoScrCast private constructor(
     }
 
     fun record(listener: StartListener): Boolean {
-        if (startListener != null) {
+        if (!CapgoRecordingCoordinator.tryAcquire()) {
             return false
         }
         startListener = listener
@@ -147,6 +148,7 @@ class CapgoScrCast private constructor(
     private fun notifyStartFailed(error: Throwable) {
         startListener?.onFailed(error)
         startListener = null
+        CapgoRecordingCoordinator.release()
     }
 
     fun stopRecording() {
@@ -175,25 +177,45 @@ class CapgoScrCast private constructor(
         }
         recordingSession = session
 
-        broadcaster.registerReceiver(
-            recordingStateHandler,
-            IntentFilter().apply {
-                addAction(STATE_IDLE)
-                addAction(STATE_RECORDING)
-            },
-        )
-
-        activity.bindService(session, connection, Context.BIND_AUTO_CREATE)
-        activity.startService(session)
+        try {
+            broadcaster.registerReceiver(
+                recordingStateHandler,
+                IntentFilter().apply {
+                    addAction(STATE_IDLE)
+                    addAction(STATE_RECORDING)
+                },
+            )
+            receiverRegistered = true
+            activity.bindService(session, connection, Context.BIND_AUTO_CREATE)
+            activity.startService(session)
+        } catch (error: Exception) {
+            Log.e("CapgoScreenRecorder", "Failed to start screen recording service", error)
+            rollbackFailedStart(error)
+        }
     }
 
-    private fun cleanupSession() {
-        startListener = null
+    private fun rollbackFailedStart(error: Throwable) {
+        unregisterRecordingReceiver()
+        recordingSession = null
+        outputFile = null
+        notifyStartFailed(error)
+    }
+
+    private fun unregisterRecordingReceiver() {
+        if (!receiverRegistered) {
+            return
+        }
         try {
             broadcaster.unregisterReceiver(recordingStateHandler)
         } catch (ignored: Exception) {
             Log.d("CapgoScreenRecorder", "Receiver already unregistered", ignored)
         }
+        receiverRegistered = false
+    }
+
+    private fun cleanupSession() {
+        startListener = null
+        unregisterRecordingReceiver()
 
         try {
             activity.unbindService(connection)
@@ -210,6 +232,7 @@ class CapgoScrCast private constructor(
             }
         }
         outputFile = null
+        CapgoRecordingCoordinator.release()
     }
 
     interface StartListener {

--- a/android/src/main/java/ee/forgr/plugin/screenrecorder/MediaRecorderPrepare.kt
+++ b/android/src/main/java/ee/forgr/plugin/screenrecorder/MediaRecorderPrepare.kt
@@ -1,13 +1,16 @@
 package ee.forgr.plugin.screenrecorder
 
 import android.media.MediaRecorder
+import java.io.IOException
 
 internal object MediaRecorderPrepare {
     fun tryPrepare(recorder: MediaRecorder?): Throwable? {
         return try {
             recorder?.prepare()
             null
-        } catch (error: Throwable) {
+        } catch (error: IOException) {
+            error
+        } catch (error: RuntimeException) {
             error
         }
     }

--- a/android/src/main/java/ee/forgr/plugin/screenrecorder/ScreenRecorderPlugin.java
+++ b/android/src/main/java/ee/forgr/plugin/screenrecorder/ScreenRecorderPlugin.java
@@ -27,33 +27,51 @@ public class ScreenRecorderPlugin extends Plugin {
 
     @PluginMethod
     public void start(final PluginCall call) {
-        final boolean recordAudio = call.getBoolean("recordAudio", false);
-        final String format = call.getString("format");
-        recordingWithAudio = recordAudio;
+        boolean keptAlive = false;
+        try {
+            final boolean recordAudio = call.getBoolean("recordAudio", false);
+            final String format = call.getString("format");
+            recordingWithAudio = recordAudio;
 
-        final CapgoScrCast recorder = recordAudio ? audioRecorder : videoRecorder;
-        final Options configuredOptions = VideoFormatResolver.INSTANCE.applyTo(recorder.getOptions(), format);
-        recorder.updateOptions(configuredOptions);
-        recorder.updateVideoFormat(format);
+            final CapgoScrCast recorder = recordAudio ? audioRecorder : videoRecorder;
+            final Options configuredOptions = VideoFormatResolver.INSTANCE.applyTo(recorder.getOptions(), format);
+            recorder.updateOptions(configuredOptions);
+            recorder.updateVideoFormat(format);
 
-        call.setKeepAlive(true);
-        recorder.record(
-            new CapgoScrCast.StartListener() {
-                @Override
-                public void onStarted() {
-                    call.resolve();
-                    call.release(bridge);
+            call.setKeepAlive(true);
+            keptAlive = true;
+            final boolean started = recorder.record(
+                new CapgoScrCast.StartListener() {
+                    @Override
+                    public void onStarted() {
+                        call.resolve();
+                        call.release(bridge);
+                    }
+
+                    @Override
+                    public void onFailed(final Throwable error) {
+                        recordingWithAudio = false;
+                        final Exception exception = error instanceof Exception ? (Exception) error : new Exception(error);
+                        call.reject("Could not start screen recording", exception);
+                        call.release(bridge);
+                    }
                 }
-
-                @Override
-                public void onFailed(final Throwable error) {
-                    recordingWithAudio = false;
-                    final Exception exception = error instanceof Exception ? (Exception) error : new Exception(error);
-                    call.reject("Could not start screen recording", exception);
-                    call.release(bridge);
-                }
+            );
+            if (!started) {
+                recordingWithAudio = false;
+                call.reject(
+                    "Could not start screen recording",
+                    new IllegalStateException("A screen recording start is already in progress")
+                );
+                call.release(bridge);
             }
-        );
+        } catch (final Exception e) {
+            recordingWithAudio = false;
+            call.reject("Could not start screen recording", e);
+            if (keptAlive) {
+                call.release(bridge);
+            }
+        }
     }
 
     @PluginMethod

--- a/android/src/main/java/ee/forgr/plugin/screenrecorder/ScreenRecorderPlugin.java
+++ b/android/src/main/java/ee/forgr/plugin/screenrecorder/ScreenRecorderPlugin.java
@@ -59,10 +59,7 @@ public class ScreenRecorderPlugin extends Plugin {
             );
             if (!started) {
                 recordingWithAudio = false;
-                call.reject(
-                    "Could not start screen recording",
-                    new IllegalStateException("A screen recording start is already in progress")
-                );
+                call.reject("Could not start screen recording", new IllegalStateException("A screen recording is already in progress"));
                 call.release(bridge);
             }
         } catch (final Exception e) {

--- a/android/src/main/java/ee/forgr/plugin/screenrecorder/service/CapgoRecorderService.kt
+++ b/android/src/main/java/ee/forgr/plugin/screenrecorder/service/CapgoRecorderService.kt
@@ -128,10 +128,12 @@ class CapgoRecorderService : Service() {
         mediaRecorder = createMediaRecorder().apply {
             if (recordAudio) {
                 setAudioSource(AudioSource.MIC)
-                setAudioEncoder(AudioEncoder.AAC)
             }
             setVideoSource(VideoSource.SURFACE)
             setOutputFormat(options.storage.outputFormat)
+            if (recordAudio) {
+                setAudioEncoder(AudioEncoder.AAC)
+            }
             setOutputFile(outputFile)
             with(options.video) {
                 setVideoSize(width, height)

--- a/android/src/test/java/ee/forgr/plugin/screenrecorder/CapgoRecordingCoordinatorTest.kt
+++ b/android/src/test/java/ee/forgr/plugin/screenrecorder/CapgoRecordingCoordinatorTest.kt
@@ -1,0 +1,17 @@
+package ee.forgr.plugin.screenrecorder
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CapgoRecordingCoordinatorTest {
+    @Test
+    fun tryAcquire_blocksConcurrentStartsUntilRelease() {
+        CapgoRecordingCoordinator.release()
+        assertTrue(CapgoRecordingCoordinator.tryAcquire())
+        assertFalse(CapgoRecordingCoordinator.tryAcquire())
+        CapgoRecordingCoordinator.release()
+        assertTrue(CapgoRecordingCoordinator.tryAcquire())
+        CapgoRecordingCoordinator.release()
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What
- Address all remaining cubic/CodeRabbit review feedback from #221

## Why
PR #221 was merged with 6 unresolved review threads covering MediaRecorder config order, exception handling, plugin call lifecycle, and test configuration.

## How
- Move `setAudioEncoder` after `setOutputFormat` in `CapgoRecorderService`
- Catch `IOException`/`RuntimeException` in `MediaRecorderPrepare` instead of `Throwable`
- Wrap `ScreenRecorderPlugin.start()` in try/catch and reject overlapping starts
- Clear `startListener` after early projection/output failures in `CapgoScrCast`
- Remove `unitTests.returnDefaultValues` from `android/build.gradle`

## Testing
- `cd android && ./gradlew test` (passes locally)

## Not Tested
- Physical device recording
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b63e61b3-752c-40aa-8dad-8e6d242967e2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b63e61b3-752c-40aa-8dad-8e6d242967e2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capacitor-screen-recorder/pr/222"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790246843&installation_model_id=430928&pr_number=222&repository=Cap-go%2Fcapacitor-screen-recorder&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapacitor-screen-recorder%2Fpull%2F222&signature=adb31d3980316737756b1cc8be2e097910bf5e12825964e98f4e593b6561c802"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capacitor-screen-recorder/pull/222?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

