### PR TITLE
Update video output file naming to include UUID

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ npx cap sync
 
 ## IOS
 
-add NSPhotoLibraryUsageDescription in your info.plist
+add NSPhotoLibraryAddUsageDescription in your info.plist
 
 ## Android
 increase project's minSdk version to 23, it's required by the dependency HBRecorder

--- a/ios/Sources/ScreenRecorderPlugin/Wyler.swift
+++ b/ios/Sources/ScreenRecorderPlugin/Wyler.swift
@@ -313,14 +313,14 @@ public final class ScreenRecorder {
                                                       handler: @escaping (Error?) -> Void) {
         let capturedOutputURL = outputURL ?? self.videoOutputURL
         let capturedDidCreate = didCreate ?? self.didCreateOutputFile
-        let status = PHPhotoLibrary.authorizationStatus(for: .addOnly)
+        let status = PHPhotoLibrary.authorizationStatus(for: .readWrite)
 
         if canSaveToPhotoLibrary(status) {
             self.saveVideoToCameraRoll(outputURL: capturedOutputURL,
                                        didCreate: capturedDidCreate,
                                        handler: handler)
         } else {
-            PHPhotoLibrary.requestAuthorization(for: .addOnly, handler: { (status) in
+            PHPhotoLibrary.requestAuthorization(for: .readWrite, handler: { (status) in
                 if self.canSaveToPhotoLibrary(status) {
                     self.saveVideoToCameraRoll(outputURL: capturedOutputURL,
                                                didCreate: capturedDidCreate,
@@ -350,6 +350,7 @@ public final class ScreenRecorder {
                 self.deleteOutputFileIfNeeded(outputURL: videoOutputURL, didCreate: didCreate)
                 handler(nil)
             } else {
+                self.deleteOutputFileIfNeeded(outputURL: videoOutputURL, didCreate: didCreate)
                 handler(NSError(domain: "ScreenRecorder",
                                 code: -1,
                                 userInfo: [NSLocalizedDescriptionKey: "Failed to save video to photo library"]))

--- a/ios/Sources/ScreenRecorderPlugin/Wyler.swift
+++ b/ios/Sources/ScreenRecorderPlugin/Wyler.swift
@@ -51,6 +51,7 @@ public enum VideoContainerFormat {
 
 public final class ScreenRecorder {
     private var videoOutputURL: URL?
+    private var didCreateOutputFile = false
     private var videoWriter: AVAssetWriter?
     private var videoWriterInput: AVAssetWriterInput?
     private var micAudioWriterInput: AVAssetWriterInput?
@@ -106,12 +107,14 @@ public final class ScreenRecorder {
         let newVideoOutputURL: URL
 
         if let passedVideoOutput = outputURL {
+            self.didCreateOutputFile = false
             self.videoOutputURL = passedVideoOutput
             newVideoOutputURL = passedVideoOutput
         } else {
             let documentsPath = NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true)[0] as NSString
             let fileName = "WylerNewVideo-\(UUID().uuidString).\(videoFormat.fileExtension)"
             newVideoOutputURL = URL(fileURLWithPath: documentsPath.appendingPathComponent(fileName))
+            self.didCreateOutputFile = true
             self.videoOutputURL = newVideoOutputURL
         }
 
@@ -225,6 +228,7 @@ public final class ScreenRecorder {
                     if self.saveToCameraRoll {
                         self.saveVideoToCameraRollAfterAuthorized(handler: handler)
                     } else {
+                        self.deleteOutputFileIfNeeded()
                         handler(nil)
                     }
                 }
@@ -234,6 +238,7 @@ public final class ScreenRecorder {
                 if self.saveToCameraRoll {
                     self.saveVideoToCameraRollAfterAuthorized(handler: handler)
                 } else {
+                    self.deleteOutputFileIfNeeded()
                     handler(nil)
                 }
             }
@@ -265,8 +270,18 @@ public final class ScreenRecorder {
             if let error = error {
                 handler(error)
             } else {
+                self.deleteOutputFileIfNeeded()
                 handler(nil)
             }
         })
+    }
+
+    private func deleteOutputFileIfNeeded() {
+        guard didCreateOutputFile, let videoOutputURL = self.videoOutputURL else { return }
+        do {
+            try FileManager.default.removeItem(at: videoOutputURL)
+        } catch {
+            debugPrint("Failed to delete recording file \(videoOutputURL): \(error)")
+        }
     }
 }

--- a/ios/Sources/ScreenRecorderPlugin/Wyler.swift
+++ b/ios/Sources/ScreenRecorderPlugin/Wyler.swift
@@ -74,11 +74,16 @@ public final class ScreenRecorder {
 
         recorder.isMicrophoneEnabled = recordAudio
 
+        var attemptOutputURL: URL?
+        var attemptDidCreate = false
+
         do {
             if recordAudio {
                 try configureAudioSession()
             }
             try createVideoWriter(in: outputURL)
+            attemptOutputURL = self.videoOutputURL
+            attemptDidCreate = self.didCreateOutputFile
             addVideoWriterInput(size: size)
             if recordAudio {
                 self.micAudioWriterInput = createAndAddAudioInput()
@@ -86,7 +91,10 @@ public final class ScreenRecorder {
             }
             startCapture(handler: handler)
         } catch let err {
-            self.deleteOutputFileIfNeeded()
+            self.deleteOutputFileIfNeeded(
+                outputURL: attemptOutputURL ?? self.videoOutputURL,
+                didCreate: attemptOutputURL != nil ? attemptDidCreate : self.didCreateOutputFile
+            )
             handler(err)
         }
     }

--- a/ios/Sources/ScreenRecorderPlugin/Wyler.swift
+++ b/ios/Sources/ScreenRecorderPlugin/Wyler.swift
@@ -91,10 +91,11 @@ public final class ScreenRecorder {
             }
             startCapture(handler: handler)
         } catch let err {
-            self.deleteOutputFileIfNeeded(
-                outputURL: attemptOutputURL ?? self.videoOutputURL,
-                didCreate: attemptOutputURL != nil ? attemptDidCreate : self.didCreateOutputFile
-            )
+            if let cleanupURL = attemptOutputURL {
+                self.deleteOutputFileIfNeeded(outputURL: cleanupURL, didCreate: attemptDidCreate)
+            } else if self.didCreateOutputFile, let cleanupURL = self.videoOutputURL {
+                self.deleteOutputFileIfNeeded(outputURL: cleanupURL, didCreate: true)
+            }
             handler(err)
         }
     }
@@ -229,7 +230,7 @@ public final class ScreenRecorder {
         recorder.stopCapture(handler: { error in
             let outputURL = self.videoOutputURL
             let didCreate = self.didCreateOutputFile
-            let saveToCameraRoll = self.saveToCameraRoll
+            let shouldSaveToCameraRoll = self.saveToCameraRoll
 
             if let error = error {
                 self.videoWriterInput?.markAsFinished()
@@ -259,7 +260,7 @@ public final class ScreenRecorder {
                         handler(finishError)
                         return
                     }
-                    if saveToCameraRoll {
+                    if shouldSaveToCameraRoll {
                         self.saveVideoToCameraRollAfterAuthorized(outputURL: outputURL,
                                                                     didCreate: didCreate,
                                                                     handler: handler)
@@ -272,7 +273,7 @@ public final class ScreenRecorder {
                 self.deleteOutputFileIfNeeded(outputURL: outputURL, didCreate: didCreate)
                 handler(writer.error)
             } else {
-                if saveToCameraRoll {
+                if shouldSaveToCameraRoll {
                     self.saveVideoToCameraRollAfterAuthorized(outputURL: outputURL,
                                                                 didCreate: didCreate,
                                                                 handler: handler)

--- a/ios/Sources/ScreenRecorderPlugin/Wyler.swift
+++ b/ios/Sources/ScreenRecorderPlugin/Wyler.swift
@@ -222,6 +222,7 @@ public final class ScreenRecorder {
             if writer.status == .writing {
                 writer.finishWriting {
                     if let finishError = writer.error {
+                        self.deleteOutputFileIfNeeded()
                         handler(finishError)
                         return
                     }
@@ -233,6 +234,7 @@ public final class ScreenRecorder {
                     }
                 }
             } else if writer.status == .failed {
+                self.deleteOutputFileIfNeeded()
                 handler(writer.error)
             } else {
                 if self.saveToCameraRoll {
@@ -253,6 +255,7 @@ public final class ScreenRecorder {
                 if status == .authorized {
                     self.saveVideoToCameraRoll(handler: handler)
                 } else {
+                    self.deleteOutputFileIfNeeded()
                     handler(ScreenRecorderError.photoLibraryAccessNotGranted)
                 }
             })
@@ -268,6 +271,7 @@ public final class ScreenRecorder {
             PHAssetChangeRequest.creationRequestForAssetFromVideo(atFileURL: videoOutputURL)
         }, completionHandler: { _, error in
             if let error = error {
+                self.deleteOutputFileIfNeeded()
                 handler(error)
             } else {
                 self.deleteOutputFileIfNeeded()

--- a/ios/Sources/ScreenRecorderPlugin/Wyler.swift
+++ b/ios/Sources/ScreenRecorderPlugin/Wyler.swift
@@ -15,6 +15,7 @@ import UIKit
 public enum ScreenRecorderError: Error {
     case notAvailable
     case photoLibraryAccessNotGranted
+    case alreadyRecording
 }
 
 public enum VideoContainerFormat {
@@ -59,6 +60,7 @@ public final class ScreenRecorder {
     private var saveToCameraRoll = false
     private var recordAudio = false
     private var videoFormat: VideoContainerFormat = .mp4
+    private var isRecording = false
     let recorder = RPScreenRecorder.shared()
 
     public func startRecording(to outputURL: URL? = nil,
@@ -67,6 +69,11 @@ public final class ScreenRecorder {
                                recordAudio: Bool = false,
                                videoFormat: VideoContainerFormat = .mp4,
                                handler: @escaping (Error?) -> Void) {
+        guard !isRecording else {
+            return handler(ScreenRecorderError.alreadyRecording)
+        }
+        isRecording = true
+
         self.saveToCameraRoll = saveToCameraRoll
         self.recordAudio = recordAudio
         self.videoFormat = videoFormat
@@ -91,6 +98,7 @@ public final class ScreenRecorder {
             }
             startCapture(handler: handler)
         } catch let err {
+            isRecording = false
             if let cleanupURL = attemptOutputURL {
                 self.deleteOutputFileIfNeeded(outputURL: cleanupURL, didCreate: attemptDidCreate)
             } else if self.didCreateOutputFile, let cleanupURL = self.videoOutputURL {
@@ -168,6 +176,7 @@ public final class ScreenRecorder {
 
         guard recorder.isAvailable else {
             self.deleteOutputFileIfNeeded(outputURL: outputURL, didCreate: didCreate)
+            self.isRecording = false
             return handler(ScreenRecorderError.notAvailable)
         }
         var sent = false
@@ -181,6 +190,7 @@ public final class ScreenRecorder {
                 }
                 self.deleteOutputFileIfNeeded(outputURL: outputURL, didCreate: didCreate)
                 if !sent {
+                    self.isRecording = false
                     handler(passedError)
                     sent = true
                 }
@@ -231,6 +241,10 @@ public final class ScreenRecorder {
             let outputURL = self.videoOutputURL
             let didCreate = self.didCreateOutputFile
             let shouldSaveToCameraRoll = self.saveToCameraRoll
+            let complete: (Error?) -> Void = { stopError in
+                self.isRecording = false
+                handler(stopError)
+            }
 
             if let error = error {
                 self.videoWriterInput?.markAsFinished()
@@ -240,7 +254,7 @@ public final class ScreenRecorder {
                     self.videoWriter?.cancelWriting()
                 }
                 self.deleteOutputFileIfNeeded(outputURL: outputURL, didCreate: didCreate)
-                handler(error)
+                complete(error)
                 return
             }
 
@@ -249,7 +263,7 @@ public final class ScreenRecorder {
             self.appAudioWriterInput?.markAsFinished()
 
             guard let writer = self.videoWriter else {
-                handler(nil)
+                complete(nil)
                 return
             }
 
@@ -257,32 +271,41 @@ public final class ScreenRecorder {
                 writer.finishWriting {
                     if let finishError = writer.error {
                         self.deleteOutputFileIfNeeded(outputURL: outputURL, didCreate: didCreate)
-                        handler(finishError)
+                        complete(finishError)
                         return
                     }
                     if shouldSaveToCameraRoll {
                         self.saveVideoToCameraRollAfterAuthorized(outputURL: outputURL,
                                                                     didCreate: didCreate,
-                                                                    handler: handler)
+                                                                    handler: complete)
                     } else {
                         self.deleteOutputFileIfNeeded(outputURL: outputURL, didCreate: didCreate)
-                        handler(nil)
+                        complete(nil)
                     }
                 }
             } else if writer.status == .failed {
                 self.deleteOutputFileIfNeeded(outputURL: outputURL, didCreate: didCreate)
-                handler(writer.error)
+                complete(writer.error)
             } else {
                 if shouldSaveToCameraRoll {
                     self.saveVideoToCameraRollAfterAuthorized(outputURL: outputURL,
                                                                 didCreate: didCreate,
-                                                                handler: handler)
+                                                                handler: complete)
                 } else {
                     self.deleteOutputFileIfNeeded(outputURL: outputURL, didCreate: didCreate)
-                    handler(nil)
+                    complete(nil)
                 }
             }
         })
+    }
+
+    private func canSaveToPhotoLibrary(_ status: PHAuthorizationStatus) -> Bool {
+        switch status {
+        case .authorized, .limited:
+            return true
+        default:
+            return false
+        }
     }
 
     private func saveVideoToCameraRollAfterAuthorized(outputURL: URL? = nil,
@@ -290,14 +313,15 @@ public final class ScreenRecorder {
                                                       handler: @escaping (Error?) -> Void) {
         let capturedOutputURL = outputURL ?? self.videoOutputURL
         let capturedDidCreate = didCreate ?? self.didCreateOutputFile
+        let status = PHPhotoLibrary.authorizationStatus(for: .addOnly)
 
-        if PHPhotoLibrary.authorizationStatus() == .authorized {
+        if canSaveToPhotoLibrary(status) {
             self.saveVideoToCameraRoll(outputURL: capturedOutputURL,
                                        didCreate: capturedDidCreate,
                                        handler: handler)
         } else {
-            PHPhotoLibrary.requestAuthorization({ (status) in
-                if status == .authorized {
+            PHPhotoLibrary.requestAuthorization(for: .addOnly, handler: { (status) in
+                if self.canSaveToPhotoLibrary(status) {
                     self.saveVideoToCameraRoll(outputURL: capturedOutputURL,
                                                didCreate: capturedDidCreate,
                                                handler: handler)
@@ -318,13 +342,17 @@ public final class ScreenRecorder {
 
         PHPhotoLibrary.shared().performChanges({
             PHAssetChangeRequest.creationRequestForAssetFromVideo(atFileURL: videoOutputURL)
-        }, completionHandler: { _, error in
+        }, completionHandler: { success, error in
             if let error = error {
                 self.deleteOutputFileIfNeeded(outputURL: videoOutputURL, didCreate: didCreate)
                 handler(error)
-            } else {
+            } else if success {
                 self.deleteOutputFileIfNeeded(outputURL: videoOutputURL, didCreate: didCreate)
                 handler(nil)
+            } else {
+                handler(NSError(domain: "ScreenRecorder",
+                                code: -1,
+                                userInfo: [NSLocalizedDescriptionKey: "Failed to save video to photo library"]))
             }
         })
     }

--- a/ios/Sources/ScreenRecorderPlugin/Wyler.swift
+++ b/ios/Sources/ScreenRecorderPlugin/Wyler.swift
@@ -158,6 +158,13 @@ public final class ScreenRecorder {
         recorder.startCapture(handler: { (sampleBuffer, sampleType, passedError) in
             if let passedError = passedError {
                 if !sent {
+                    self.videoWriterInput?.markAsFinished()
+                    self.micAudioWriterInput?.markAsFinished()
+                    self.appAudioWriterInput?.markAsFinished()
+                    if self.videoWriter?.status == .writing {
+                        self.videoWriter?.cancelWriting()
+                    }
+                    self.deleteOutputFileIfNeeded()
                     handler(passedError)
                     sent = true
                 }
@@ -205,7 +212,17 @@ public final class ScreenRecorder {
 
     public func stoprecording(handler: @escaping (Error?) -> Void) {
         recorder.stopCapture(handler: { error in
+            let outputURL = self.videoOutputURL
+            let didCreate = self.didCreateOutputFile
+
             if let error = error {
+                self.videoWriterInput?.markAsFinished()
+                self.micAudioWriterInput?.markAsFinished()
+                self.appAudioWriterInput?.markAsFinished()
+                if self.videoWriter?.status == .writing {
+                    self.videoWriter?.cancelWriting()
+                }
+                self.deleteOutputFileIfNeeded(outputURL: outputURL, didCreate: didCreate)
                 handler(error)
                 return
             }
@@ -222,48 +239,63 @@ public final class ScreenRecorder {
             if writer.status == .writing {
                 writer.finishWriting {
                     if let finishError = writer.error {
-                        self.deleteOutputFileIfNeeded()
+                        self.deleteOutputFileIfNeeded(outputURL: outputURL, didCreate: didCreate)
                         handler(finishError)
                         return
                     }
                     if self.saveToCameraRoll {
-                        self.saveVideoToCameraRollAfterAuthorized(handler: handler)
+                        self.saveVideoToCameraRollAfterAuthorized(outputURL: outputURL,
+                                                                    didCreate: didCreate,
+                                                                    handler: handler)
                     } else {
-                        self.deleteOutputFileIfNeeded()
+                        self.deleteOutputFileIfNeeded(outputURL: outputURL, didCreate: didCreate)
                         handler(nil)
                     }
                 }
             } else if writer.status == .failed {
-                self.deleteOutputFileIfNeeded()
+                self.deleteOutputFileIfNeeded(outputURL: outputURL, didCreate: didCreate)
                 handler(writer.error)
             } else {
                 if self.saveToCameraRoll {
-                    self.saveVideoToCameraRollAfterAuthorized(handler: handler)
+                    self.saveVideoToCameraRollAfterAuthorized(outputURL: outputURL,
+                                                                didCreate: didCreate,
+                                                                handler: handler)
                 } else {
-                    self.deleteOutputFileIfNeeded()
+                    self.deleteOutputFileIfNeeded(outputURL: outputURL, didCreate: didCreate)
                     handler(nil)
                 }
             }
         })
     }
 
-    private func saveVideoToCameraRollAfterAuthorized(handler: @escaping (Error?) -> Void) {
+    private func saveVideoToCameraRollAfterAuthorized(outputURL: URL? = nil,
+                                                      didCreate: Bool? = nil,
+                                                      handler: @escaping (Error?) -> Void) {
+        let capturedOutputURL = outputURL ?? self.videoOutputURL
+        let capturedDidCreate = didCreate ?? self.didCreateOutputFile
+
         if PHPhotoLibrary.authorizationStatus() == .authorized {
-            self.saveVideoToCameraRoll(handler: handler)
+            self.saveVideoToCameraRoll(outputURL: capturedOutputURL,
+                                       didCreate: capturedDidCreate,
+                                       handler: handler)
         } else {
             PHPhotoLibrary.requestAuthorization({ (status) in
                 if status == .authorized {
-                    self.saveVideoToCameraRoll(handler: handler)
+                    self.saveVideoToCameraRoll(outputURL: capturedOutputURL,
+                                               didCreate: capturedDidCreate,
+                                               handler: handler)
                 } else {
-                    self.deleteOutputFileIfNeeded()
+                    self.deleteOutputFileIfNeeded(outputURL: capturedOutputURL, didCreate: capturedDidCreate)
                     handler(ScreenRecorderError.photoLibraryAccessNotGranted)
                 }
             })
         }
     }
 
-    private func saveVideoToCameraRoll(handler: @escaping (Error?) -> Void) {
-        guard let videoOutputURL = self.videoOutputURL else {
+    private func saveVideoToCameraRoll(outputURL: URL?,
+                                       didCreate: Bool,
+                                       handler: @escaping (Error?) -> Void) {
+        guard let videoOutputURL = outputURL else {
             return handler(nil)
         }
 
@@ -271,21 +303,22 @@ public final class ScreenRecorder {
             PHAssetChangeRequest.creationRequestForAssetFromVideo(atFileURL: videoOutputURL)
         }, completionHandler: { _, error in
             if let error = error {
-                self.deleteOutputFileIfNeeded()
+                self.deleteOutputFileIfNeeded(outputURL: videoOutputURL, didCreate: didCreate)
                 handler(error)
             } else {
-                self.deleteOutputFileIfNeeded()
+                self.deleteOutputFileIfNeeded(outputURL: videoOutputURL, didCreate: didCreate)
                 handler(nil)
             }
         })
     }
 
-    private func deleteOutputFileIfNeeded() {
-        guard didCreateOutputFile, let videoOutputURL = self.videoOutputURL else { return }
+    private func deleteOutputFileIfNeeded(outputURL: URL? = nil, didCreate: Bool? = nil) {
+        let shouldDelete = didCreate ?? didCreateOutputFile
+        guard shouldDelete, let fileURL = outputURL ?? self.videoOutputURL else { return }
         do {
-            try FileManager.default.removeItem(at: videoOutputURL)
+            try FileManager.default.removeItem(at: fileURL)
         } catch {
-            debugPrint("Failed to delete recording file \(videoOutputURL): \(error)")
+            debugPrint("Failed to delete recording file \(fileURL): \(error)")
         }
     }
 }

--- a/ios/Sources/ScreenRecorderPlugin/Wyler.swift
+++ b/ios/Sources/ScreenRecorderPlugin/Wyler.swift
@@ -110,7 +110,7 @@ public final class ScreenRecorder {
             newVideoOutputURL = passedVideoOutput
         } else {
             let documentsPath = NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true)[0] as NSString
-            let fileName = "WylerNewVideo.\(videoFormat.fileExtension)"
+            let fileName = "WylerNewVideo-\(UUID().uuidString).\(videoFormat.fileExtension)"
             newVideoOutputURL = URL(fileURLWithPath: documentsPath.appendingPathComponent(fileName))
             self.videoOutputURL = newVideoOutputURL
         }

--- a/ios/Sources/ScreenRecorderPlugin/Wyler.swift
+++ b/ios/Sources/ScreenRecorderPlugin/Wyler.swift
@@ -86,6 +86,7 @@ public final class ScreenRecorder {
             }
             startCapture(handler: handler)
         } catch let err {
+            self.deleteOutputFileIfNeeded()
             handler(err)
         }
     }
@@ -151,7 +152,11 @@ public final class ScreenRecorder {
     }
 
     private func startCapture(handler: @escaping (Error?) -> Void) {
+        let outputURL = self.videoOutputURL
+        let didCreate = self.didCreateOutputFile
+
         guard recorder.isAvailable else {
+            self.deleteOutputFileIfNeeded(outputURL: outputURL, didCreate: didCreate)
             return handler(ScreenRecorderError.notAvailable)
         }
         var sent = false
@@ -163,7 +168,7 @@ public final class ScreenRecorder {
                 if self.videoWriter?.status == .writing {
                     self.videoWriter?.cancelWriting()
                 }
-                self.deleteOutputFileIfNeeded()
+                self.deleteOutputFileIfNeeded(outputURL: outputURL, didCreate: didCreate)
                 if !sent {
                     handler(passedError)
                     sent = true

--- a/ios/Sources/ScreenRecorderPlugin/Wyler.swift
+++ b/ios/Sources/ScreenRecorderPlugin/Wyler.swift
@@ -96,6 +96,8 @@ public final class ScreenRecorder {
         videoWriterInput = nil
         micAudioWriterInput = nil
         appAudioWriterInput = nil
+        videoOutputURL = nil
+        didCreateOutputFile = false
     }
 
     private func configureAudioSession() throws {
@@ -219,6 +221,7 @@ public final class ScreenRecorder {
         recorder.stopCapture(handler: { error in
             let outputURL = self.videoOutputURL
             let didCreate = self.didCreateOutputFile
+            let saveToCameraRoll = self.saveToCameraRoll
 
             if let error = error {
                 self.videoWriterInput?.markAsFinished()
@@ -248,7 +251,7 @@ public final class ScreenRecorder {
                         handler(finishError)
                         return
                     }
-                    if self.saveToCameraRoll {
+                    if saveToCameraRoll {
                         self.saveVideoToCameraRollAfterAuthorized(outputURL: outputURL,
                                                                     didCreate: didCreate,
                                                                     handler: handler)
@@ -261,7 +264,7 @@ public final class ScreenRecorder {
                 self.deleteOutputFileIfNeeded(outputURL: outputURL, didCreate: didCreate)
                 handler(writer.error)
             } else {
-                if self.saveToCameraRoll {
+                if saveToCameraRoll {
                     self.saveVideoToCameraRollAfterAuthorized(outputURL: outputURL,
                                                                 didCreate: didCreate,
                                                                 handler: handler)

--- a/ios/Sources/ScreenRecorderPlugin/Wyler.swift
+++ b/ios/Sources/ScreenRecorderPlugin/Wyler.swift
@@ -313,14 +313,14 @@ public final class ScreenRecorder {
                                                       handler: @escaping (Error?) -> Void) {
         let capturedOutputURL = outputURL ?? self.videoOutputURL
         let capturedDidCreate = didCreate ?? self.didCreateOutputFile
-        let status = PHPhotoLibrary.authorizationStatus(for: .readWrite)
+        let status = PHPhotoLibrary.authorizationStatus(for: .addOnly)
 
         if canSaveToPhotoLibrary(status) {
             self.saveVideoToCameraRoll(outputURL: capturedOutputURL,
                                        didCreate: capturedDidCreate,
                                        handler: handler)
         } else {
-            PHPhotoLibrary.requestAuthorization(for: .readWrite, handler: { (status) in
+            PHPhotoLibrary.requestAuthorization(for: .addOnly, handler: { (status) in
                 if self.canSaveToPhotoLibrary(status) {
                     self.saveVideoToCameraRoll(outputURL: capturedOutputURL,
                                                didCreate: capturedDidCreate,

--- a/ios/Sources/ScreenRecorderPlugin/Wyler.swift
+++ b/ios/Sources/ScreenRecorderPlugin/Wyler.swift
@@ -157,14 +157,14 @@ public final class ScreenRecorder {
         var sent = false
         recorder.startCapture(handler: { (sampleBuffer, sampleType, passedError) in
             if let passedError = passedError {
+                self.videoWriterInput?.markAsFinished()
+                self.micAudioWriterInput?.markAsFinished()
+                self.appAudioWriterInput?.markAsFinished()
+                if self.videoWriter?.status == .writing {
+                    self.videoWriter?.cancelWriting()
+                }
+                self.deleteOutputFileIfNeeded()
                 if !sent {
-                    self.videoWriterInput?.markAsFinished()
-                    self.micAudioWriterInput?.markAsFinished()
-                    self.appAudioWriterInput?.markAsFinished()
-                    if self.videoWriter?.status == .writing {
-                        self.videoWriter?.cancelWriting()
-                    }
-                    self.deleteOutputFileIfNeeded()
                     handler(passedError)
                     sent = true
                 }


### PR DESCRIPTION
This pull request makes a small but important change to how video output files are named in the `ScreenRecorder` class. The filename now includes a unique UUID to prevent overwriting existing files when multiple recordings are saved.

* [`ios/Sources/ScreenRecorderPlugin/Wyler.swift`](diffhunk://#diff-9edce73f9e1f1f484e5b2b77df41fe96ea124f1164cce33ad034117c823e62aeL113-R113): Updated the video output filename to include a UUID, ensuring each recording is saved with a unique name.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capacitor-screen-recorder/pr/227"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791353281&installation_model_id=430928&pr_number=227&repository=Cap-go%2Fcapacitor-screen-recorder&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapacitor-screen-recorder%2Fpull%2F227&signature=479e7df1dc692bf0e01b33043d174280d5e3ce659806ffa9faa1b2a9e1d423de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capacitor-screen-recorder/pull/227?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented consecutive recordings from overwriting one another when no output filename is provided.
  * Recordings now receive unique filenames automatically.
  * Automatically generated recording files are cleaned up when setup, capture, recording, authorization, or saving fails, and after recording completion.
  * Caller-provided output files are preserved.
  * Improved cleanup after recording and saving errors to prevent incomplete recording sessions or lingering temporary files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->