### PR TITLE
feat(android): emit 'onStopped' event when a recording ends without stop()

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,8 @@ Listen for recordings that ended without {@link stop} being called —
 the user stopped the capture from the system UI (Android "Stop sharing")
 or the recorder terminated itself (max duration / max file size).
 
+This event is currently only emitted on Android; iOS support is planned.
+
 | Param              | Type                                                                                                  | Description                                                                                                     |
 | ------------------ | ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
 | **`eventName`**    | <code>'onStopped'</code>                                                                              | - `onStopped`                                                                                                   |

--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ No configuration required for this plugin.
 
 * [`start(...)`](#start)
 * [`stop()`](#stop)
+* [`addListener('onStopped', ...)`](#addlisteneronstopped-)
+* [`removeAllListeners()`](#removealllisteners)
 * [`getPluginVersion()`](#getpluginversion)
 * [Interfaces](#interfaces)
 * [Type Aliases](#type-aliases)
@@ -154,6 +156,41 @@ recording. On Android, the video is saved directly to the gallery.
 --------------------
 
 
+### addListener('onStopped', ...)
+
+```typescript
+addListener(eventName: 'onStopped', listenerFunc: (event: ScreenRecorderStoppedEvent) => void) => Promise<PluginListenerHandle>
+```
+
+Listen for recordings that ended without {@link stop} being called —
+the user stopped the capture from the system UI (Android "Stop sharing")
+or the recorder terminated itself (max duration / max file size).
+
+| Param              | Type                                                                                                  | Description                                                                                                     |
+| ------------------ | ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| **`eventName`**    | <code>'onStopped'</code>                                                                              | - `onStopped`                                                                                                   |
+| **`listenerFunc`** | <code>(event: <a href="#screenrecorderstoppedevent">ScreenRecorderStoppedEvent</a>) =&gt; void</code> | - Called with the local URI of the finished file and the error message when the recording ended with a failure. |
+
+**Returns:** <code>Promise&lt;<a href="#pluginlistenerhandle">PluginListenerHandle</a>&gt;</code>
+
+**Since:** 8.4.0
+
+--------------------
+
+
+### removeAllListeners()
+
+```typescript
+removeAllListeners() => Promise<void>
+```
+
+Remove all listeners registered with {@link addListener}.
+
+**Since:** 8.4.0
+
+--------------------
+
+
 ### getPluginVersion()
 
 ```typescript
@@ -180,6 +217,28 @@ Options for {@link ScreenRecorderPlugin.start}.
 | ----------------- | ------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------ | ----- |
 | **`recordAudio`** | <code>boolean</code>                                                                                                | Whether to record audio along with the screen video.                                                                                                                                                                | <code>false</code> | 1.0.0 |
 | **`format`**      | <code><a href="#screenrecordervideoformat">ScreenRecorderVideoFormat</a> \| 'video/mp4' \| 'video/quicktime'</code> | Video container format for the saved recording. Accepts `mp4`, `mov`, or MIME types `video/mp4` and `video/quicktime`. iOS supports both `mp4` and `mov`. Android records MPEG-4 (`.mp4`) regardless of this value. | <code>'mp4'</code> | 8.3.0 |
+
+
+#### PluginListenerHandle
+
+| Prop         | Type                                      |
+| ------------ | ----------------------------------------- |
+| **`remove`** | <code>() =&gt; Promise&lt;void&gt;</code> |
+
+
+#### ScreenRecorderStoppedEvent
+
+Payload for the `onStopped` event.
+
+Fired when a recording ends without {@link ScreenRecorderPlugin.stop} being
+called — the user stopped the capture from the system UI (Android
+"Stop sharing") or the recorder terminated itself (max duration / max file
+size).
+
+| Prop        | Type                | Description                                                                                                        | Since |
+| ----------- | ------------------- | ------------------------------------------------------------------------------------------------------------------ | ----- |
+| **`url`**   | <code>string</code> | Local URI of the finished recording (`file://` on Android). Empty string when the file path could not be resolved. | 8.4.0 |
+| **`error`** | <code>string</code> | Error message when the recording ended with a failure.                                                             | 8.4.0 |
 
 
 ### Type Aliases

--- a/README.md
+++ b/README.md
@@ -163,10 +163,9 @@ addListener(eventName: 'onStopped', listenerFunc: (event: ScreenRecorderStoppedE
 ```
 
 Listen for recordings that ended without {@link stop} being called —
-the user stopped the capture from the system UI (Android "Stop sharing")
-or the recorder terminated itself (max duration / max file size).
-
-This event is currently only emitted on Android; iOS support is planned.
+the user stopped the capture from the system UI (Android "Stop sharing"),
+the recorder terminated itself (max duration / max file size), or the
+system interrupted the capture (iOS, e.g. an incoming call).
 
 | Param              | Type                                                                                                  | Description                                                                                                     |
 | ------------------ | ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |

--- a/android/src/main/java/ee/forgr/plugin/screenrecorder/CapgoScrCast.kt
+++ b/android/src/main/java/ee/forgr/plugin/screenrecorder/CapgoScrCast.kt
@@ -253,8 +253,11 @@ class CapgoScrCast private constructor(
 
         val savedPath = outputFile?.absolutePath
         savedPath?.let { path ->
-            MediaScannerConnection.scanFile(activity, arrayOf(path), null) { path, uri ->
-                Log.i("CapgoScreenRecorder", "Saved recording: $path uri=$uri")
+            val file = File(path)
+            if (file.isFile && file.length() > 0L) {
+                MediaScannerConnection.scanFile(activity, arrayOf(path), null) { path, uri ->
+                    Log.i("CapgoScreenRecorder", "Saved recording: $path uri=$uri")
+                }
             }
         }
         outputFile = null

--- a/android/src/main/java/ee/forgr/plugin/screenrecorder/CapgoScrCast.kt
+++ b/android/src/main/java/ee/forgr/plugin/screenrecorder/CapgoScrCast.kt
@@ -87,6 +87,11 @@ class CapgoScrCast private constructor(
                     val error = intent.getSerializableExtra(EXTRA_ERROR) as? Throwable
                     if (error != null) {
                         startListener?.onFailed(error)
+                    } else if (startPending) {
+                        // The session ended before recording started and no
+                        // failure was reported (e.g. the service was destroyed
+                        // first) — settle the kept-alive start call anyway.
+                        startListener?.onFailed(IllegalStateException("Recording stopped before it started"))
                     }
                     val savedPath = cleanupSession()
                     if (!startPending && sessionActive && !stopRequested) {

--- a/android/src/main/java/ee/forgr/plugin/screenrecorder/CapgoScrCast.kt
+++ b/android/src/main/java/ee/forgr/plugin/screenrecorder/CapgoScrCast.kt
@@ -252,17 +252,20 @@ class CapgoScrCast private constructor(
         recordingSession = null
 
         val savedPath = outputFile?.absolutePath
-        savedPath?.let { path ->
+        val deliverablePath = savedPath?.let { path ->
             val file = File(path)
             if (file.isFile && file.length() > 0L) {
                 MediaScannerConnection.scanFile(activity, arrayOf(path), null) { path, uri ->
                     Log.i("CapgoScreenRecorder", "Saved recording: $path uri=$uri")
                 }
+                path
+            } else {
+                null
             }
         }
         outputFile = null
         CapgoRecordingCoordinator.release()
-        return savedPath
+        return deliverablePath
     }
 
     interface StartListener {

--- a/android/src/main/java/ee/forgr/plugin/screenrecorder/CapgoScrCast.kt
+++ b/android/src/main/java/ee/forgr/plugin/screenrecorder/CapgoScrCast.kt
@@ -166,6 +166,9 @@ class CapgoScrCast private constructor(
     }
 
     fun stopRecording() {
+        if (recordingSession == null) {
+            return
+        }
         stopRequested = true
         broadcaster.sendBroadcast(Intent(Action.Stop.name))
     }
@@ -181,6 +184,7 @@ class CapgoScrCast private constructor(
 
     private fun startService(result: ActivityResult, file: File) {
         outputFile = file
+        stopRequested = false
         val session = Intent(activity, CapgoRecorderService::class.java).apply {
             putExtra("code", result.resultCode)
             putExtra("data", result.data)
@@ -213,6 +217,7 @@ class CapgoScrCast private constructor(
         unregisterRecordingReceiver()
         recordingSession = null
         outputFile = null
+        stopRequested = false
         notifyStartFailed(error)
     }
 

--- a/android/src/main/java/ee/forgr/plugin/screenrecorder/CapgoScrCast.kt
+++ b/android/src/main/java/ee/forgr/plugin/screenrecorder/CapgoScrCast.kt
@@ -40,6 +40,14 @@ class CapgoScrCast private constructor(
     private var serviceBinder: CapgoRecorderService? = null
     private var outputFile: File? = null
     private var startListener: StartListener? = null
+    private var stopRequested = false
+
+    /**
+     * Notified when a recording ends without [stopRecording] having been
+     * involved — the user stopped it from the system UI or the recorder
+     * terminated itself (max duration / max size).
+     */
+    var externalStopListener: ExternalStopListener? = null
     private var receiverRegistered = false
 
     private val metrics by lazy {
@@ -74,11 +82,17 @@ class CapgoScrCast private constructor(
                     startListener = null
                 }
                 STATE_IDLE -> {
+                    val startPending = startListener != null
+                    val sessionActive = recordingSession != null
                     val error = intent.getSerializableExtra(EXTRA_ERROR) as? Throwable
                     if (error != null) {
                         startListener?.onFailed(error)
                     }
-                    cleanupSession()
+                    val savedPath = cleanupSession()
+                    if (!startPending && sessionActive && !stopRequested) {
+                        externalStopListener?.onExternalStop(savedPath, error?.message)
+                    }
+                    stopRequested = false
                 }
             }
         }
@@ -152,6 +166,7 @@ class CapgoScrCast private constructor(
     }
 
     fun stopRecording() {
+        stopRequested = true
         broadcaster.sendBroadcast(Intent(Action.Stop.name))
     }
 
@@ -213,7 +228,7 @@ class CapgoScrCast private constructor(
         receiverRegistered = false
     }
 
-    private fun cleanupSession() {
+    private fun cleanupSession(): String? {
         startListener = null
         unregisterRecordingReceiver()
 
@@ -226,18 +241,24 @@ class CapgoScrCast private constructor(
         recordingSession?.let { activity.stopService(it) }
         recordingSession = null
 
-        outputFile?.let { file ->
-            MediaScannerConnection.scanFile(activity, arrayOf(file.absolutePath), null) { path, uri ->
+        val savedPath = outputFile?.absolutePath
+        savedPath?.let { path ->
+            MediaScannerConnection.scanFile(activity, arrayOf(path), null) { path, uri ->
                 Log.i("CapgoScreenRecorder", "Saved recording: $path uri=$uri")
             }
         }
         outputFile = null
         CapgoRecordingCoordinator.release()
+        return savedPath
     }
 
     interface StartListener {
         fun onStarted()
         fun onFailed(error: Throwable)
+    }
+
+    interface ExternalStopListener {
+        fun onExternalStop(path: String?, error: String?)
     }
 
     companion object {

--- a/android/src/main/java/ee/forgr/plugin/screenrecorder/CapgoScrCast.kt
+++ b/android/src/main/java/ee/forgr/plugin/screenrecorder/CapgoScrCast.kt
@@ -257,7 +257,7 @@ class CapgoScrCast private constructor(
         fun onFailed(error: Throwable)
     }
 
-    interface ExternalStopListener {
+    fun interface ExternalStopListener {
         fun onExternalStop(path: String?, error: String?)
     }
 

--- a/android/src/main/java/ee/forgr/plugin/screenrecorder/ScreenRecorderPlugin.java
+++ b/android/src/main/java/ee/forgr/plugin/screenrecorder/ScreenRecorderPlugin.java
@@ -1,11 +1,13 @@
 package ee.forgr.plugin.screenrecorder;
 
+import android.net.Uri;
 import com.getcapacitor.JSObject;
 import com.getcapacitor.Plugin;
 import com.getcapacitor.PluginCall;
 import com.getcapacitor.PluginMethod;
 import com.getcapacitor.annotation.CapacitorPlugin;
 import dev.bmcreations.scrcast.config.Options;
+import java.io.File;
 
 @CapacitorPlugin(name = "ScreenRecorder")
 public class ScreenRecorderPlugin extends Plugin {
@@ -23,6 +25,22 @@ public class ScreenRecorderPlugin extends Plugin {
         final Options options = new Options();
         videoRecorder.updateOptions(options);
         audioRecorder.updateOptions(options);
+
+        final CapgoScrCast.ExternalStopListener externalStopListener =
+            new CapgoScrCast.ExternalStopListener() {
+                @Override
+                public void onExternalStop(final String path, final String error) {
+                    recordingWithAudio = false;
+                    final JSObject ret = new JSObject();
+                    ret.put("url", path != null ? Uri.fromFile(new File(path)).toString() : "");
+                    if (error != null) {
+                        ret.put("error", error);
+                    }
+                    notifyListeners("onStopped", ret);
+                }
+            };
+        videoRecorder.setExternalStopListener(externalStopListener);
+        audioRecorder.setExternalStopListener(externalStopListener);
     }
 
     @PluginMethod

--- a/android/src/main/java/ee/forgr/plugin/screenrecorder/ScreenRecorderPlugin.java
+++ b/android/src/main/java/ee/forgr/plugin/screenrecorder/ScreenRecorderPlugin.java
@@ -26,19 +26,18 @@ public class ScreenRecorderPlugin extends Plugin {
         videoRecorder.updateOptions(options);
         audioRecorder.updateOptions(options);
 
-        final CapgoScrCast.ExternalStopListener externalStopListener =
-            new CapgoScrCast.ExternalStopListener() {
-                @Override
-                public void onExternalStop(final String path, final String error) {
-                    recordingWithAudio = false;
-                    final JSObject ret = new JSObject();
-                    ret.put("url", path != null ? Uri.fromFile(new File(path)).toString() : "");
-                    if (error != null) {
-                        ret.put("error", error);
-                    }
-                    notifyListeners("onStopped", ret);
+        final CapgoScrCast.ExternalStopListener externalStopListener = new CapgoScrCast.ExternalStopListener() {
+            @Override
+            public void onExternalStop(final String path, final String error) {
+                recordingWithAudio = false;
+                final JSObject ret = new JSObject();
+                ret.put("url", path != null ? Uri.fromFile(new File(path)).toString() : "");
+                if (error != null) {
+                    ret.put("error", error);
                 }
-            };
+                notifyListeners("onStopped", ret);
+            }
+        };
         videoRecorder.setExternalStopListener(externalStopListener);
         audioRecorder.setExternalStopListener(externalStopListener);
     }

--- a/android/src/main/java/ee/forgr/plugin/screenrecorder/service/CapgoRecorderService.kt
+++ b/android/src/main/java/ee/forgr/plugin/screenrecorder/service/CapgoRecorderService.kt
@@ -306,8 +306,11 @@ class CapgoRecorderService : Service() {
             val hadStarted = recordingStarted
             cleanupProjection()
             when {
-                state is RecordingState.Idle -> {
-                    // stopRecording() already published Idle (with or without error).
+                state is RecordingState.Idle && (state as RecordingState.Idle).error != null -> {
+                    // stopRecording() already published Idle with an error.
+                }
+                state is RecordingState.Idle && hadStarted -> {
+                    // stopRecording() already published Idle for an active recording.
                 }
                 !hadStarted -> {
                     state = RecordingState.Idle(

--- a/android/src/main/java/ee/forgr/plugin/screenrecorder/service/CapgoRecorderService.kt
+++ b/android/src/main/java/ee/forgr/plugin/screenrecorder/service/CapgoRecorderService.kt
@@ -301,7 +301,12 @@ class CapgoRecorderService : Service() {
             // recording and publish Idle here, or the plugin would never learn
             // that the session ended.
             cleanupProjection()
-            state = RecordingState.Idle()
+            val error = if (state !is RecordingState.Recording) {
+                IllegalStateException("Recording stopped before it started")
+            } else {
+                null
+            }
+            state = RecordingState.Idle(error)
             stopForeground(true)
         }
     }

--- a/android/src/main/java/ee/forgr/plugin/screenrecorder/service/CapgoRecorderService.kt
+++ b/android/src/main/java/ee/forgr/plugin/screenrecorder/service/CapgoRecorderService.kt
@@ -112,6 +112,7 @@ class CapgoRecorderService : Service() {
         }
 
     private var mediaRecorder: MediaRecorder? = null
+    private var recordingStarted = false
 
 
     private fun createMediaRecorder(): MediaRecorder {
@@ -265,6 +266,7 @@ class CapgoRecorderService : Service() {
             virtualDisplay // touch
             try {
                 mediaRecorder?.start()
+                recordingStarted = true
                 state = RecordingState.Recording
                 notificationProvider.update(state)
             } catch (e: Exception) {
@@ -291,6 +293,7 @@ class CapgoRecorderService : Service() {
             mediaRecorder?.stop()
         }
         releaseRecorder()
+        recordingStarted = false
     }
 
     private inner class MediaProjectionCallback : MediaProjection.Callback() {
@@ -300,14 +303,23 @@ class CapgoRecorderService : Service() {
             // tapped the system "Stop sharing" control — so finalize the
             // recording and publish Idle here, or the plugin would never learn
             // that the session ended.
+            val hadStarted = recordingStarted
             cleanupProjection()
-            val error = if (state !is RecordingState.Recording) {
-                IllegalStateException("Recording stopped before it started")
-            } else {
-                null
+            when {
+                state is RecordingState.Idle -> {
+                    // stopRecording() already published Idle (with or without error).
+                }
+                !hadStarted -> {
+                    state = RecordingState.Idle(
+                        IllegalStateException("Recording stopped before it started"),
+                    )
+                    stopForeground(true)
+                }
+                else -> {
+                    state = RecordingState.Idle()
+                    stopForeground(true)
+                }
             }
-            state = RecordingState.Idle(error)
-            stopForeground(true)
         }
     }
 

--- a/android/src/main/java/ee/forgr/plugin/screenrecorder/service/CapgoRecorderService.kt
+++ b/android/src/main/java/ee/forgr/plugin/screenrecorder/service/CapgoRecorderService.kt
@@ -113,6 +113,7 @@ class CapgoRecorderService : Service() {
 
     private var mediaRecorder: MediaRecorder? = null
     private var recordingStarted = false
+    private var prepareInProgress = false
 
 
     private fun createMediaRecorder(): MediaRecorder {
@@ -239,6 +240,7 @@ class CapgoRecorderService : Service() {
 
     private fun recordInternal(code: Int, data: Intent) {
         GlobalScope.launch(Dispatchers.Main) {
+            prepareInProgress = true
             startForeground(
                 notificationProvider.getNotificationId(),
                 notificationProvider.get(state)
@@ -260,6 +262,7 @@ class CapgoRecorderService : Service() {
 
             mediaProjection?.registerCallback(mediaProjectionCallback, Handler())
             if (!createRecorder()) {
+                prepareInProgress = false
                 stopRecording(IOException("MediaRecorder prepare failed"))
                 return@launch
             }
@@ -271,6 +274,8 @@ class CapgoRecorderService : Service() {
                 notificationProvider.update(state)
             } catch (e: Exception) {
                 stopRecording(e)
+            } finally {
+                prepareInProgress = false
             }
         }
     }
@@ -294,6 +299,7 @@ class CapgoRecorderService : Service() {
         }
         releaseRecorder()
         recordingStarted = false
+        prepareInProgress = false
     }
 
     private inner class MediaProjectionCallback : MediaProjection.Callback() {
@@ -304,6 +310,7 @@ class CapgoRecorderService : Service() {
             // recording and publish Idle here, or the plugin would never learn
             // that the session ended.
             val hadStarted = recordingStarted
+            val preparing = prepareInProgress
             cleanupProjection()
             when {
                 state is RecordingState.Idle && (state as RecordingState.Idle).error != null -> {
@@ -312,7 +319,7 @@ class CapgoRecorderService : Service() {
                 state is RecordingState.Idle && hadStarted -> {
                     // stopRecording() already published Idle for an active recording.
                 }
-                !hadStarted -> {
+                !hadStarted || preparing -> {
                     state = RecordingState.Idle(
                         IllegalStateException("Recording stopped before it started"),
                     )

--- a/android/src/main/java/ee/forgr/plugin/screenrecorder/service/CapgoRecorderService.kt
+++ b/android/src/main/java/ee/forgr/plugin/screenrecorder/service/CapgoRecorderService.kt
@@ -296,7 +296,13 @@ class CapgoRecorderService : Service() {
     private inner class MediaProjectionCallback : MediaProjection.Callback() {
         override fun onStop() {
             Log.d("scrcast", "projection on stop")
+            // The projection was stopped outside of stopRecording() — the user
+            // tapped the system "Stop sharing" control — so finalize the
+            // recording and publish Idle here, or the plugin would never learn
+            // that the session ended.
             cleanupProjection()
+            state = RecordingState.Idle()
+            stopForeground(true)
         }
     }
 

--- a/ios/Sources/ScreenRecorderPlugin/ScreenRecorderPlugin.swift
+++ b/ios/Sources/ScreenRecorderPlugin/ScreenRecorderPlugin.swift
@@ -17,6 +17,17 @@ public class ScreenRecorderPlugin: CAPPlugin, CAPBridgedPlugin {
     ]
     private let implementation = ScreenRecorder()
 
+    override public func load() {
+        implementation.onExternalStop = { [weak self] url, error in
+            guard let self = self else { return }
+            var data: [String: Any] = ["url": url?.absoluteString ?? ""]
+            if let error = error {
+                data["error"] = error.localizedDescription
+            }
+            self.notifyListeners("onStopped", data: data)
+        }
+    }
+
     @objc func start(_ call: CAPPluginCall) {
         let recordAudio = call.getBool("recordAudio") ?? false
         let videoFormat = VideoContainerFormat.from(call.getString("format"))

--- a/ios/Sources/ScreenRecorderPlugin/Wyler.swift
+++ b/ios/Sources/ScreenRecorderPlugin/Wyler.swift
@@ -323,7 +323,9 @@ public final class ScreenRecorder: NSObject {
         recorder.stopCapture(handler: { error in
             if let error = error {
                 self.settlePendingStart(error)
-                self.finishWriterAndDeliver(snapshot: snapshot, handler: handler)
+                self.finishWriterAndDeliver(snapshot: snapshot, handler: { _ in
+                    handler(error)
+                })
                 return
             }
 

--- a/ios/Sources/ScreenRecorderPlugin/Wyler.swift
+++ b/ios/Sources/ScreenRecorderPlugin/Wyler.swift
@@ -68,6 +68,7 @@ public final class ScreenRecorder: NSObject {
     private var stopRequested = false
     private var pendingStartHandler: ((Error?) -> Void)?
     private var videoWritingStarted = false
+    private var isFinalizing = false
 
     public func startRecording(to outputURL: URL? = nil,
                                size: CGSize? = nil,
@@ -77,7 +78,7 @@ public final class ScreenRecorder: NSObject {
                                handler: @escaping (Error?) -> Void) {
         // Reject before any writer/session state is touched: a second start
         // while the first is still pending must not disturb the first capture.
-        guard pendingStartHandler == nil else {
+        guard pendingStartHandler == nil, !isFinalizing else {
             return handler(ScreenRecorderError.captureAlreadyPending)
         }
         self.saveToCameraRoll = saveToCameraRoll
@@ -186,8 +187,14 @@ public final class ScreenRecorder: NSObject {
 
             switch sampleType {
             case .video:
-                self.handleSampleBuffer(sampleBuffer: sampleBuffer)
-                self.settlePendingStart(nil)
+                if self.handleSampleBuffer(sampleBuffer: sampleBuffer) {
+                    self.settlePendingStart(nil)
+                } else if let writer = self.videoWriter, writer.status == .failed {
+                    let error = writer.error ?? ScreenRecorderError.captureInterrupted
+                    if !self.settlePendingStart(error) {
+                        self.handleRecordingEndedExternally(error: error)
+                    }
+                }
             case .audioApp:
                 if self.recordAudio {
                     self.add(sample: sampleBuffer, to: self.appAudioWriterInput)
@@ -219,17 +226,27 @@ public final class ScreenRecorder: NSObject {
         return true
     }
 
-    private func handleSampleBuffer(sampleBuffer: CMSampleBuffer) {
-        if self.videoWriter?.status == AVAssetWriter.Status.unknown {
-            self.videoWriter?.startWriting()
-            self.videoWriter?.startSession(atSourceTime: CMSampleBufferGetPresentationTimeStamp(sampleBuffer))
-        }
-        if self.videoWriter?.status == AVAssetWriter.Status.writing {
-            videoWritingStarted = true
-            if self.videoWriterInput?.isReadyForMoreMediaData == true {
-                self.videoWriterInput?.append(sampleBuffer)
+    @discardableResult
+    private func handleSampleBuffer(sampleBuffer: CMSampleBuffer) -> Bool {
+        guard let writer = videoWriter else { return false }
+        if writer.status == AVAssetWriter.Status.unknown {
+            writer.startWriting()
+            if writer.status == .failed {
+                return false
+            }
+            writer.startSession(atSourceTime: CMSampleBufferGetPresentationTimeStamp(sampleBuffer))
+            if writer.status == .failed {
+                return false
             }
         }
+        guard writer.status == AVAssetWriter.Status.writing else {
+            return false
+        }
+        videoWritingStarted = true
+        if videoWriterInput?.isReadyForMoreMediaData == true {
+            videoWriterInput?.append(sampleBuffer)
+        }
+        return true
     }
 
     private func add(sample: CMSampleBuffer, to writerInput: AVAssetWriterInput?) {
@@ -244,6 +261,7 @@ public final class ScreenRecorder: NSObject {
         stopRequested = true
         let outputURL = videoOutputURL
         let hadVideoContent = videoWritingStarted
+        let saveToCameraRoll = saveToCameraRoll
         recorder.stopCapture(handler: { error in
             if let error = error {
                 self.settlePendingStart(error)
@@ -258,6 +276,7 @@ public final class ScreenRecorder: NSObject {
             self.finishWriterAndDeliver(
                 outputURL: outputURL,
                 hasVideoContent: hadVideoContent,
+                saveToCameraRoll: saveToCameraRoll,
                 handler: handler
             )
         })
@@ -266,13 +285,21 @@ public final class ScreenRecorder: NSObject {
     private func finishWriterAndDeliver(
         outputURL: URL?,
         hasVideoContent: Bool,
+        saveToCameraRoll: Bool,
         handler: @escaping (Error?) -> Void
     ) {
-        videoWriterInput?.markAsFinished()
-        micAudioWriterInput?.markAsFinished()
-        appAudioWriterInput?.markAsFinished()
+        isFinalizing = true
+        let writer = videoWriter
+        let videoInput = videoWriterInput
+        let micInput = micAudioWriterInput
+        let appInput = appAudioWriterInput
 
-        guard let writer = videoWriter else {
+        videoInput?.markAsFinished()
+        micInput?.markAsFinished()
+        appInput?.markAsFinished()
+
+        guard let writer = writer else {
+            isFinalizing = false
             handler(nil)
             return
         }
@@ -280,21 +307,40 @@ public final class ScreenRecorder: NSObject {
         if writer.status == .writing {
             writer.finishWriting {
                 if let finishError = writer.error {
+                    self.isFinalizing = false
                     handler(finishError)
                     return
                 }
-                self.deliverOutput(url: outputURL, hasVideoContent: hasVideoContent, handler: handler)
+                self.deliverOutput(
+                    url: outputURL,
+                    hasVideoContent: hasVideoContent,
+                    saveToCameraRoll: saveToCameraRoll,
+                    handler: { error in
+                        self.isFinalizing = false
+                        handler(error)
+                    }
+                )
             }
         } else if writer.status == .failed {
+            isFinalizing = false
             handler(writer.error)
         } else {
-            self.deliverOutput(url: outputURL, hasVideoContent: hasVideoContent, handler: handler)
+            deliverOutput(
+                url: outputURL,
+                hasVideoContent: hasVideoContent,
+                saveToCameraRoll: saveToCameraRoll,
+                handler: { error in
+                    self.isFinalizing = false
+                    handler(error)
+                }
+            )
         }
     }
 
     private func deliverOutput(
         url: URL?,
         hasVideoContent: Bool,
+        saveToCameraRoll: Bool,
         handler: @escaping (Error?) -> Void
     ) {
         guard hasVideoContent else {
@@ -316,9 +362,11 @@ public final class ScreenRecorder: NSObject {
         // recording's URL (and save its file to the camera roll).
         let outputURL = videoOutputURL
         let hadVideoContent = videoWritingStarted
+        let saveToCameraRoll = saveToCameraRoll
         finishWriterAndDeliver(
             outputURL: outputURL,
             hasVideoContent: hadVideoContent,
+            saveToCameraRoll: saveToCameraRoll,
             handler: { finishError in
                 let url = hadVideoContent ? outputURL : nil
                 self.onExternalStop?(url, error ?? finishError)

--- a/ios/Sources/ScreenRecorderPlugin/Wyler.swift
+++ b/ios/Sources/ScreenRecorderPlugin/Wyler.swift
@@ -100,15 +100,15 @@ public final class ScreenRecorder: NSObject {
                 return ScreenRecorderError.captureAlreadyPending
             }
             stopRequested = false
+            self.saveToCameraRoll = saveToCameraRoll
+            self.recordAudio = recordAudio
+            self.videoFormat = videoFormat
+            resetWriterState()
             return nil
         }
         if let rejectError {
             return handler(rejectError)
         }
-        self.saveToCameraRoll = saveToCameraRoll
-        self.recordAudio = recordAudio
-        self.videoFormat = videoFormat
-        resetWriterState()
         recorder.delegate = self
 
         recorder.isMicrophoneEnabled = recordAudio
@@ -117,11 +117,13 @@ public final class ScreenRecorder: NSObject {
             if recordAudio {
                 try configureAudioSession()
             }
-            try createVideoWriter(in: outputURL)
-            addVideoWriterInput(size: size)
-            if recordAudio {
-                self.micAudioWriterInput = createAndAddAudioInput()
-                self.appAudioWriterInput = createAndAddAudioInput()
+            try withStateLock {
+                try createVideoWriter(in: outputURL)
+                addVideoWriterInput(size: size)
+                if recordAudio {
+                    self.micAudioWriterInput = createAndAddAudioInput()
+                    self.appAudioWriterInput = createAndAddAudioInput()
+                }
             }
             startCapture(handler: handler)
         } catch let err {
@@ -134,9 +136,7 @@ public final class ScreenRecorder: NSObject {
         videoWriterInput = nil
         micAudioWriterInput = nil
         appAudioWriterInput = nil
-        withStateLock {
-            videoWritingStarted = false
-        }
+        videoWritingStarted = false
     }
 
     private func configureAudioSession() throws {
@@ -216,10 +216,17 @@ public final class ScreenRecorder: NSObject {
             case .video:
                 if self.handleSampleBuffer(sampleBuffer: sampleBuffer) {
                     self.settlePendingStart(nil)
-                } else if let writer = self.videoWriter, writer.status == .failed {
-                    let error = writer.error ?? ScreenRecorderError.captureInterrupted
-                    if !self.settlePendingStart(error) {
-                        self.handleRecordingEndedExternally(error: error)
+                } else {
+                    let error: Error? = self.withStateLock {
+                        guard let writer = videoWriter, writer.status == .failed else {
+                            return nil
+                        }
+                        return writer.error ?? ScreenRecorderError.captureInterrupted
+                    }
+                    if let error = error {
+                        if !self.settlePendingStart(error) {
+                            self.handleRecordingEndedExternally(error: error)
+                        }
                     }
                 }
             case .audioApp:
@@ -261,34 +268,36 @@ public final class ScreenRecorder: NSObject {
 
     @discardableResult
     private func handleSampleBuffer(sampleBuffer: CMSampleBuffer) -> Bool {
-        guard let writer = videoWriter else { return false }
-        if writer.status == AVAssetWriter.Status.unknown {
-            writer.startWriting()
-            if writer.status == .failed {
+        return withStateLock {
+            guard let writer = videoWriter else { return false }
+            if writer.status == AVAssetWriter.Status.unknown {
+                writer.startWriting()
+                if writer.status == .failed {
+                    return false
+                }
+                writer.startSession(atSourceTime: CMSampleBufferGetPresentationTimeStamp(sampleBuffer))
+                if writer.status == .failed {
+                    return false
+                }
+            }
+            guard writer.status == AVAssetWriter.Status.writing else {
                 return false
             }
-            writer.startSession(atSourceTime: CMSampleBufferGetPresentationTimeStamp(sampleBuffer))
-            if writer.status == .failed {
-                return false
-            }
-        }
-        guard writer.status == AVAssetWriter.Status.writing else {
-            return false
-        }
-        withStateLock {
             videoWritingStarted = true
+            if videoWriterInput?.isReadyForMoreMediaData == true {
+                videoWriterInput?.append(sampleBuffer)
+            }
+            return true
         }
-        if videoWriterInput?.isReadyForMoreMediaData == true {
-            videoWriterInput?.append(sampleBuffer)
-        }
-        return true
     }
 
     private func add(sample: CMSampleBuffer, to writerInput: AVAssetWriterInput?) {
-        guard let writerInput = writerInput else { return }
-        guard self.videoWriter?.status == .writing else { return }
-        if writerInput.isReadyForMoreMediaData {
-            writerInput.append(sample)
+        withStateLock {
+            guard let writerInput = writerInput else { return }
+            guard self.videoWriter?.status == .writing else { return }
+            if writerInput.isReadyForMoreMediaData {
+                writerInput.append(sample)
+            }
         }
     }
 

--- a/ios/Sources/ScreenRecorderPlugin/Wyler.swift
+++ b/ios/Sources/ScreenRecorderPlugin/Wyler.swift
@@ -302,7 +302,8 @@ public final class ScreenRecorder: NSObject {
     }
 
     public func stoprecording(handler: @escaping (Error?) -> Void) {
-        let snapshot = withStateLock { () -> FinalizationSnapshot in
+        let snapshot: FinalizationSnapshot? = withStateLock { () -> FinalizationSnapshot? in
+            guard !isFinalizing else { return nil }
             stopRequested = true
             isFinalizing = true
             return FinalizationSnapshot(
@@ -315,13 +316,14 @@ public final class ScreenRecorder: NSObject {
                 saveToCameraRoll: saveToCameraRoll
             )
         }
+        guard let snapshot else {
+            handler(nil)
+            return
+        }
         recorder.stopCapture(handler: { error in
             if let error = error {
-                withStateLock {
-                    isFinalizing = false
-                }
                 self.settlePendingStart(error)
-                handler(error)
+                self.finishWriterAndDeliver(snapshot: snapshot, handler: handler)
                 return
             }
 

--- a/ios/Sources/ScreenRecorderPlugin/Wyler.swift
+++ b/ios/Sources/ScreenRecorderPlugin/Wyler.swift
@@ -64,6 +64,7 @@ public final class ScreenRecorder: NSObject {
     public var onExternalStop: ((URL?, Error?) -> Void)?
     private var isRecording = false
     private var stopRequested = false
+    private var pendingStartHandler: ((Error?) -> Void)?
 
     public func startRecording(to outputURL: URL? = nil,
                                size: CGSize? = nil,
@@ -159,6 +160,9 @@ public final class ScreenRecorder: NSObject {
             return handler(ScreenRecorderError.notAvailable)
         }
         isRecording = true
+        // Retained until the first sample settles the start, so the delegate
+        // can reject a start whose capture stopped before any sample arrived.
+        pendingStartHandler = handler
         var sent = false
         recorder.startCapture(handler: { (sampleBuffer, sampleType, passedError) in
             if let passedError = passedError {
@@ -166,6 +170,7 @@ public final class ScreenRecorder: NSObject {
                     // The capture never started — clear the flag so a later
                     // delegate callback cannot report this as an external stop.
                     self.isRecording = false
+                    self.pendingStartHandler = nil
                     handler(passedError)
                     sent = true
                 }
@@ -187,6 +192,7 @@ public final class ScreenRecorder: NSObject {
                 break
             }
             if !sent {
+                self.pendingStartHandler = nil
                 handler(nil)
                 sent = true
             }
@@ -308,6 +314,14 @@ extension ScreenRecorder: RPScreenRecorderDelegate {
         didStopRecordingWithError error: Error,
         previewViewController _: RPPreviewViewController?
     ) {
+        if let startHandler = pendingStartHandler {
+            // The capture stopped before the first sample: settle the still
+            // pending start instead of reporting an external stop.
+            pendingStartHandler = nil
+            isRecording = false
+            startHandler(error)
+            return
+        }
         handleRecordingEndedExternally(error: error)
     }
 }

--- a/ios/Sources/ScreenRecorderPlugin/Wyler.swift
+++ b/ios/Sources/ScreenRecorderPlugin/Wyler.swift
@@ -67,6 +67,7 @@ public final class ScreenRecorder: NSObject {
     private var isRecording = false
     private var stopRequested = false
     private var pendingStartHandler: ((Error?) -> Void)?
+    private var videoWritingStarted = false
 
     public func startRecording(to outputURL: URL? = nil,
                                size: CGSize? = nil,
@@ -109,6 +110,7 @@ public final class ScreenRecorder: NSObject {
         videoWriterInput = nil
         micAudioWriterInput = nil
         appAudioWriterInput = nil
+        videoWritingStarted = false
     }
 
     private func configureAudioSession() throws {
@@ -176,13 +178,16 @@ public final class ScreenRecorder: NSObject {
             if let passedError = passedError {
                 // Fails a still-pending start; once the start is settled the
                 // delegate owns the end-of-capture reporting.
-                self.settlePendingStart(passedError)
+                if !self.settlePendingStart(passedError) {
+                    self.handleRecordingEndedExternally(error: passedError)
+                }
                 return
             }
 
             switch sampleType {
             case .video:
                 self.handleSampleBuffer(sampleBuffer: sampleBuffer)
+                self.settlePendingStart(nil)
             case .audioApp:
                 if self.recordAudio {
                     self.add(sample: sampleBuffer, to: self.appAudioWriterInput)
@@ -194,7 +199,6 @@ public final class ScreenRecorder: NSObject {
             default:
                 break
             }
-            self.settlePendingStart(nil)
         })
     }
 
@@ -219,6 +223,7 @@ public final class ScreenRecorder: NSObject {
         if self.videoWriter?.status == AVAssetWriter.Status.unknown {
             self.videoWriter?.startWriting()
             self.videoWriter?.startSession(atSourceTime: CMSampleBufferGetPresentationTimeStamp(sampleBuffer))
+            videoWritingStarted = true
         } else if self.videoWriter?.status == AVAssetWriter.Status.writing &&
                     self.videoWriterInput?.isReadyForMoreMediaData == true {
             self.videoWriterInput?.append(sampleBuffer)
@@ -277,6 +282,10 @@ public final class ScreenRecorder: NSObject {
     }
 
     private func deliverOutput(url: URL?, handler: @escaping (Error?) -> Void) {
+        guard videoWritingStarted else {
+            handler(nil)
+            return
+        }
         if saveToCameraRoll {
             saveVideoToCameraRollAfterAuthorized(url: url, handler: handler)
         } else {
@@ -293,7 +302,8 @@ public final class ScreenRecorder: NSObject {
         let outputURL = videoOutputURL
         finishWriterAndDeliver(outputURL: outputURL, handler: { [weak self] finishError in
             guard let self = self else { return }
-            self.onExternalStop?(outputURL, error ?? finishError)
+            let url = self.videoWritingStarted ? outputURL : nil
+            self.onExternalStop?(url, error ?? finishError)
         })
     }
 

--- a/ios/Sources/ScreenRecorderPlugin/Wyler.swift
+++ b/ios/Sources/ScreenRecorderPlugin/Wyler.swift
@@ -154,19 +154,18 @@ public final class ScreenRecorder: NSObject {
             invalidateDelegateSession()
             recorder.stopCapture(handler: { [weak self] _ in
                 guard let self = self else { return }
-                let shouldContinue = withStateLock {
-                    pendingRestartDrain && restartDrainGeneration == drainGeneration
-                }
-                guard shouldContinue else {
-                    withStateLock {
+                let shouldContinue = withStateLock { () -> Bool in
+                    guard pendingRestartDrain && restartDrainGeneration == drainGeneration else {
                         restartDrainInFlight = false
+                        return false
                     }
-                    handler(ScreenRecorderError.captureAlreadyPending)
-                    return
-                }
-                withStateLock {
                     pendingRestartDrain = false
                     restartDrainInFlight = false
+                    return true
+                }
+                guard shouldContinue else {
+                    handler(ScreenRecorderError.captureAlreadyPending)
+                    return
                 }
                 self.startRecording(
                     to: outputURL,

--- a/ios/Sources/ScreenRecorderPlugin/Wyler.swift
+++ b/ios/Sources/ScreenRecorderPlugin/Wyler.swift
@@ -71,6 +71,16 @@ public final class ScreenRecorder: NSObject {
     private var isFinalizing = false
     private let stateLock = NSLock()
 
+    private struct FinalizationSnapshot {
+        let outputURL: URL?
+        let writer: AVAssetWriter?
+        let videoInput: AVAssetWriterInput?
+        let micInput: AVAssetWriterInput?
+        let appInput: AVAssetWriterInput?
+        let hasVideoContent: Bool
+        let saveToCameraRoll: Bool
+    }
+
     private func withStateLock<T>(_ body: () throws -> T) rethrows -> T {
         stateLock.lock()
         defer { stateLock.unlock() }
@@ -283,13 +293,18 @@ public final class ScreenRecorder: NSObject {
     }
 
     public func stoprecording(handler: @escaping (Error?) -> Void) {
-        let snapshots: (URL?, Bool, Bool) = withStateLock {
+        let snapshot = withStateLock { () -> FinalizationSnapshot in
             stopRequested = true
-            return (videoOutputURL, videoWritingStarted, saveToCameraRoll)
+            return FinalizationSnapshot(
+                outputURL: videoOutputURL,
+                writer: videoWriter,
+                videoInput: videoWriterInput,
+                micInput: micAudioWriterInput,
+                appInput: appAudioWriterInput,
+                hasVideoContent: videoWritingStarted,
+                saveToCameraRoll: saveToCameraRoll
+            )
         }
-        let outputURL = snapshots.0
-        let hadVideoContent = snapshots.1
-        let saveToCameraRoll = snapshots.2
         recorder.stopCapture(handler: { error in
             if let error = error {
                 self.settlePendingStart(error)
@@ -303,28 +318,21 @@ public final class ScreenRecorder: NSObject {
             // stop() may arrive before the first sample: settle the pending
             // start so the caller's start promise does not hang.
             self.settlePendingStart(ScreenRecorderError.captureInterrupted)
-            self.finishWriterAndDeliver(
-                outputURL: outputURL,
-                hasVideoContent: hadVideoContent,
-                saveToCameraRoll: saveToCameraRoll,
-                handler: handler
-            )
+            self.finishWriterAndDeliver(snapshot: snapshot, handler: handler)
         })
     }
 
     private func finishWriterAndDeliver(
-        outputURL: URL?,
-        hasVideoContent: Bool,
-        saveToCameraRoll: Bool,
+        snapshot: FinalizationSnapshot,
         handler: @escaping (Error?) -> Void
     ) {
         withStateLock {
             isFinalizing = true
         }
-        let writer = videoWriter
-        let videoInput = videoWriterInput
-        let micInput = micAudioWriterInput
-        let appInput = appAudioWriterInput
+        let writer = snapshot.writer
+        let videoInput = snapshot.videoInput
+        let micInput = snapshot.micInput
+        let appInput = snapshot.appInput
 
         videoInput?.markAsFinished()
         micInput?.markAsFinished()
@@ -348,9 +356,9 @@ public final class ScreenRecorder: NSObject {
                     return
                 }
                 self.deliverOutput(
-                    url: outputURL,
-                    hasVideoContent: hasVideoContent,
-                    saveToCameraRoll: saveToCameraRoll,
+                    url: snapshot.outputURL,
+                    hasVideoContent: snapshot.hasVideoContent,
+                    saveToCameraRoll: snapshot.saveToCameraRoll,
                     handler: { error in
                         withStateLock {
                             isFinalizing = false
@@ -366,9 +374,9 @@ public final class ScreenRecorder: NSObject {
             handler(writer.error)
         } else {
             deliverOutput(
-                url: outputURL,
-                hasVideoContent: hasVideoContent,
-                saveToCameraRoll: saveToCameraRoll,
+                url: snapshot.outputURL,
+                hasVideoContent: snapshot.hasVideoContent,
+                saveToCameraRoll: snapshot.saveToCameraRoll,
                 handler: { error in
                     withStateLock {
                         isFinalizing = false
@@ -397,24 +405,24 @@ public final class ScreenRecorder: NSObject {
     }
 
     private func handleRecordingEndedExternally(error: Error?) {
-        let session: (URL?, Bool, Bool)? = withStateLock {
+        let snapshot: FinalizationSnapshot? = withStateLock {
             guard isRecording, !stopRequested else { return nil }
             isRecording = false
-            return (videoOutputURL, videoWritingStarted, saveToCameraRoll)
+            return FinalizationSnapshot(
+                outputURL: videoOutputURL,
+                writer: videoWriter,
+                videoInput: videoWriterInput,
+                micInput: micAudioWriterInput,
+                appInput: appAudioWriterInput,
+                hasVideoContent: videoWritingStarted,
+                saveToCameraRoll: saveToCameraRoll
+            )
         }
-        guard let session else { return }
-        let outputURL = session.0
-        let hadVideoContent = session.1
-        let saveToCameraRoll = session.2
-        finishWriterAndDeliver(
-            outputURL: outputURL,
-            hasVideoContent: hadVideoContent,
-            saveToCameraRoll: saveToCameraRoll,
-            handler: { finishError in
-                let url = hadVideoContent ? outputURL : nil
-                self.onExternalStop?(url, error ?? finishError)
-            }
-        )
+        guard let snapshot else { return }
+        finishWriterAndDeliver(snapshot: snapshot, handler: { finishError in
+            let url = snapshot.hasVideoContent ? snapshot.outputURL : nil
+            self.onExternalStop?(url, error ?? finishError)
+        })
     }
 
     private func saveVideoToCameraRollAfterAuthorized(url: URL?, handler: @escaping (Error?) -> Void) {

--- a/ios/Sources/ScreenRecorderPlugin/Wyler.swift
+++ b/ios/Sources/ScreenRecorderPlugin/Wyler.swift
@@ -304,6 +304,7 @@ public final class ScreenRecorder: NSObject {
     public func stoprecording(handler: @escaping (Error?) -> Void) {
         let snapshot = withStateLock { () -> FinalizationSnapshot in
             stopRequested = true
+            isFinalizing = true
             return FinalizationSnapshot(
                 outputURL: videoOutputURL,
                 writer: videoWriter,
@@ -316,6 +317,9 @@ public final class ScreenRecorder: NSObject {
         }
         recorder.stopCapture(handler: { error in
             if let error = error {
+                withStateLock {
+                    isFinalizing = false
+                }
                 self.settlePendingStart(error)
                 handler(error)
                 return
@@ -335,9 +339,6 @@ public final class ScreenRecorder: NSObject {
         snapshot: FinalizationSnapshot,
         handler: @escaping (Error?) -> Void
     ) {
-        withStateLock {
-            isFinalizing = true
-        }
         let writer = snapshot.writer
         let videoInput = snapshot.videoInput
         let micInput = snapshot.micInput
@@ -417,6 +418,7 @@ public final class ScreenRecorder: NSObject {
         let snapshot: FinalizationSnapshot? = withStateLock {
             guard isRecording, !stopRequested else { return nil }
             isRecording = false
+            isFinalizing = true
             return FinalizationSnapshot(
                 outputURL: videoOutputURL,
                 writer: videoWriter,

--- a/ios/Sources/ScreenRecorderPlugin/Wyler.swift
+++ b/ios/Sources/ScreenRecorderPlugin/Wyler.swift
@@ -49,7 +49,7 @@ public enum VideoContainerFormat {
     }
 }
 
-public final class ScreenRecorder {
+public final class ScreenRecorder: NSObject {
     private var videoOutputURL: URL?
     private var videoWriter: AVAssetWriter?
     private var videoWriterInput: AVAssetWriterInput?
@@ -59,6 +59,11 @@ public final class ScreenRecorder {
     private var recordAudio = false
     private var videoFormat: VideoContainerFormat = .mp4
     let recorder = RPScreenRecorder.shared()
+    /// Notified when the recording ends without `stoprecording()` being
+    /// involved — the system stopped the capture (interruption, error).
+    public var onExternalStop: ((URL?, Error?) -> Void)?
+    private var isRecording = false
+    private var stopRequested = false
 
     public func startRecording(to outputURL: URL? = nil,
                                size: CGSize? = nil,
@@ -70,6 +75,8 @@ public final class ScreenRecorder {
         self.recordAudio = recordAudio
         self.videoFormat = videoFormat
         resetWriterState()
+        stopRequested = false
+        recorder.delegate = self
 
         recorder.isMicrophoneEnabled = recordAudio
 
@@ -151,6 +158,7 @@ public final class ScreenRecorder {
         guard recorder.isAvailable else {
             return handler(ScreenRecorderError.notAvailable)
         }
+        isRecording = true
         var sent = false
         recorder.startCapture(handler: { (sampleBuffer, sampleType, passedError) in
             if let passedError = passedError {
@@ -201,42 +209,57 @@ public final class ScreenRecorder {
     }
 
     public func stoprecording(handler: @escaping (Error?) -> Void) {
+        stopRequested = true
         recorder.stopCapture(handler: { error in
             if let error = error {
                 handler(error)
                 return
             }
 
-            self.videoWriterInput?.markAsFinished()
-            self.micAudioWriterInput?.markAsFinished()
-            self.appAudioWriterInput?.markAsFinished()
+            self.isRecording = false
+            self.finishWriterAndDeliver(handler: handler)
+        })
+    }
 
-            guard let writer = self.videoWriter else {
-                handler(nil)
-                return
-            }
+    private func finishWriterAndDeliver(handler: @escaping (Error?) -> Void) {
+        videoWriterInput?.markAsFinished()
+        micAudioWriterInput?.markAsFinished()
+        appAudioWriterInput?.markAsFinished()
 
-            if writer.status == .writing {
-                writer.finishWriting {
-                    if let finishError = writer.error {
-                        handler(finishError)
-                        return
-                    }
-                    if self.saveToCameraRoll {
-                        self.saveVideoToCameraRollAfterAuthorized(handler: handler)
-                    } else {
-                        handler(nil)
-                    }
+        guard let writer = videoWriter else {
+            handler(nil)
+            return
+        }
+
+        if writer.status == .writing {
+            writer.finishWriting {
+                if let finishError = writer.error {
+                    handler(finishError)
+                    return
                 }
-            } else if writer.status == .failed {
-                handler(writer.error)
-            } else {
-                if self.saveToCameraRoll {
-                    self.saveVideoToCameraRollAfterAuthorized(handler: handler)
-                } else {
-                    handler(nil)
-                }
+                self.deliverOutput(handler: handler)
             }
+        } else if writer.status == .failed {
+            handler(writer.error)
+        } else {
+            self.deliverOutput(handler: handler)
+        }
+    }
+
+    private func deliverOutput(handler: @escaping (Error?) -> Void) {
+        if saveToCameraRoll {
+            saveVideoToCameraRollAfterAuthorized(handler: handler)
+        } else {
+            handler(nil)
+        }
+    }
+
+    private func handleRecordingEndedExternally(error: Error?) {
+        guard isRecording, !stopRequested else { return }
+        isRecording = false
+        finishWriterAndDeliver(handler: { [weak self] finishError in
+            guard let self = self else { return }
+            self.onExternalStop?(self.videoOutputURL, error ?? finishError)
         })
     }
 
@@ -268,5 +291,13 @@ public final class ScreenRecorder {
                 handler(nil)
             }
         })
+    }
+}
+
+extension ScreenRecorder: RPScreenRecorderDelegate {
+    public func screenRecorder(_ screenRecorder: RPScreenRecorder,
+                               didStopRecordingWithError error: Error,
+                               previewViewController: RPPreviewViewController?) {
+        handleRecordingEndedExternally(error: error)
     }
 }

--- a/ios/Sources/ScreenRecorderPlugin/Wyler.swift
+++ b/ios/Sources/ScreenRecorderPlugin/Wyler.swift
@@ -74,6 +74,11 @@ public final class ScreenRecorder: NSObject {
                                recordAudio: Bool = false,
                                videoFormat: VideoContainerFormat = .mp4,
                                handler: @escaping (Error?) -> Void) {
+        // Reject before any writer/session state is touched: a second start
+        // while the first is still pending must not disturb the first capture.
+        guard pendingStartHandler == nil else {
+            return handler(ScreenRecorderError.captureAlreadyPending)
+        }
         self.saveToCameraRoll = saveToCameraRoll
         self.recordAudio = recordAudio
         self.videoFormat = videoFormat
@@ -160,9 +165,6 @@ public final class ScreenRecorder: NSObject {
     private func startCapture(handler: @escaping (Error?) -> Void) {
         guard recorder.isAvailable else {
             return handler(ScreenRecorderError.notAvailable)
-        }
-        guard pendingStartHandler == nil else {
-            return handler(ScreenRecorderError.captureAlreadyPending)
         }
         isRecording = true
         // The start is settled exactly once — by the first sample, a capture

--- a/ios/Sources/ScreenRecorderPlugin/Wyler.swift
+++ b/ios/Sources/ScreenRecorderPlugin/Wyler.swift
@@ -74,6 +74,7 @@ public final class ScreenRecorder: NSObject {
     private var recordingEstablishedSessionID: UInt64 = 0
     private var pendingRestartDrain = false
     private var restartDrainGeneration: UInt64 = 0
+    private var restartDrainInFlight = false
     private let stateLock = NSLock()
 
     private struct FinalizationSnapshot {
@@ -139,6 +140,16 @@ public final class ScreenRecorder: NSObject {
                                videoFormat: VideoContainerFormat = .mp4,
                                handler: @escaping (Error?) -> Void) {
         if withStateLock({ pendingRestartDrain }) {
+            let alreadyWaiting = withStateLock { () -> Bool in
+                if restartDrainInFlight {
+                    return true
+                }
+                restartDrainInFlight = true
+                return false
+            }
+            if alreadyWaiting {
+                return handler(ScreenRecorderError.captureAlreadyPending)
+            }
             let drainGeneration = withStateLock { restartDrainGeneration }
             invalidateDelegateSession()
             recorder.stopCapture(handler: { [weak self] _ in
@@ -146,9 +157,16 @@ public final class ScreenRecorder: NSObject {
                 let shouldContinue = withStateLock {
                     pendingRestartDrain && restartDrainGeneration == drainGeneration
                 }
-                guard shouldContinue else { return }
+                guard shouldContinue else {
+                    withStateLock {
+                        restartDrainInFlight = false
+                    }
+                    handler(ScreenRecorderError.captureAlreadyPending)
+                    return
+                }
                 withStateLock {
                     pendingRestartDrain = false
+                    restartDrainInFlight = false
                 }
                 self.startRecording(
                     to: outputURL,

--- a/ios/Sources/ScreenRecorderPlugin/Wyler.swift
+++ b/ios/Sources/ScreenRecorderPlugin/Wyler.swift
@@ -15,6 +15,8 @@ import UIKit
 public enum ScreenRecorderError: Error {
     case notAvailable
     case photoLibraryAccessNotGranted
+    case captureAlreadyPending
+    case captureInterrupted
 }
 
 public enum VideoContainerFormat {
@@ -159,21 +161,20 @@ public final class ScreenRecorder: NSObject {
         guard recorder.isAvailable else {
             return handler(ScreenRecorderError.notAvailable)
         }
+        guard pendingStartHandler == nil else {
+            return handler(ScreenRecorderError.captureAlreadyPending)
+        }
         isRecording = true
-        // Retained until the first sample settles the start, so the delegate
-        // can reject a start whose capture stopped before any sample arrived.
+        // The start is settled exactly once — by the first sample, a capture
+        // failure, the delegate, or stoprecording() — whichever comes first,
+        // so the plugin's start promise never hangs and never settles twice.
         pendingStartHandler = handler
-        var sent = false
-        recorder.startCapture(handler: { (sampleBuffer, sampleType, passedError) in
+        recorder.startCapture(handler: { [weak self] (sampleBuffer, sampleType, passedError) in
+            guard let self = self else { return }
             if let passedError = passedError {
-                if !sent {
-                    // The capture never started — clear the flag so a later
-                    // delegate callback cannot report this as an external stop.
-                    self.isRecording = false
-                    self.pendingStartHandler = nil
-                    handler(passedError)
-                    sent = true
-                }
+                // Fails a still-pending start; once the start is settled the
+                // delegate owns the end-of-capture reporting.
+                self.settlePendingStart(passedError)
                 return
             }
 
@@ -191,12 +192,25 @@ public final class ScreenRecorder: NSObject {
             default:
                 break
             }
-            if !sent {
-                self.pendingStartHandler = nil
-                handler(nil)
-                sent = true
-            }
+            self.settlePendingStart(nil)
         })
+    }
+
+    /// Settles the pending start exactly once. Returns true when this call
+    /// settled it. A failure also clears `isRecording`, because the capture
+    /// never produced output; once settled, end-of-capture reporting belongs
+    /// to the delegate / stoprecording().
+    @discardableResult
+    private func settlePendingStart(_ error: Error?) -> Bool {
+        guard let startHandler = pendingStartHandler else {
+            return false
+        }
+        pendingStartHandler = nil
+        if error != nil {
+            isRecording = false
+        }
+        startHandler(error)
+        return true
     }
 
     private func handleSampleBuffer(sampleBuffer: CMSampleBuffer) {
@@ -222,11 +236,15 @@ public final class ScreenRecorder: NSObject {
         let outputURL = videoOutputURL
         recorder.stopCapture(handler: { error in
             if let error = error {
+                self.settlePendingStart(error)
                 handler(error)
                 return
             }
 
             self.isRecording = false
+            // stop() may arrive before the first sample: settle the pending
+            // start so the caller's start promise does not hang.
+            self.settlePendingStart(ScreenRecorderError.captureInterrupted)
             self.finishWriterAndDeliver(outputURL: outputURL, handler: handler)
         })
     }
@@ -314,14 +332,10 @@ extension ScreenRecorder: RPScreenRecorderDelegate {
         didStopRecordingWithError error: Error,
         previewViewController _: RPPreviewViewController?
     ) {
-        if let startHandler = pendingStartHandler {
-            // The capture stopped before the first sample: settle the still
-            // pending start instead of reporting an external stop.
-            pendingStartHandler = nil
-            isRecording = false
-            startHandler(error)
-            return
+        // A stop before the first sample fails the still-pending start; only
+        // a capture that was actually running is an external stop.
+        if !settlePendingStart(error) {
+            handleRecordingEndedExternally(error: error)
         }
-        handleRecordingEndedExternally(error: error)
     }
 }

--- a/ios/Sources/ScreenRecorderPlugin/Wyler.swift
+++ b/ios/Sources/ScreenRecorderPlugin/Wyler.swift
@@ -155,12 +155,12 @@ public final class ScreenRecorder: NSObject {
             recorder.stopCapture(handler: { [weak self] _ in
                 guard let self = self else { return }
                 let shouldContinue = withStateLock { () -> Bool in
-                    guard pendingRestartDrain && restartDrainGeneration == drainGeneration else {
-                        restartDrainInFlight = false
+                    guard self.pendingRestartDrain && self.restartDrainGeneration == drainGeneration else {
+                        self.restartDrainInFlight = false
                         return false
                     }
-                    pendingRestartDrain = false
-                    restartDrainInFlight = false
+                    self.pendingRestartDrain = false
+                    self.restartDrainInFlight = false
                     return true
                 }
                 guard shouldContinue else {
@@ -298,10 +298,10 @@ public final class ScreenRecorder: NSObject {
             self.invalidateDelegateSession()
             guard self.isActiveCaptureSession(sessionID) else { return }
             withStateLock {
-                pendingRestartDrain = false
+                self.pendingRestartDrain = false
             }
             withStateLock {
-                delegateSessionID = sessionID
+                self.delegateSessionID = sessionID
             }
             self.recorder.delegate = self
             self.recorder.startCapture(handler: { [weak self] (sampleBuffer, sampleType, passedError) in
@@ -322,7 +322,7 @@ public final class ScreenRecorder: NSObject {
                         self.settlePendingStart(nil)
                     } else {
                         let error: Error? = self.withStateLock {
-                            guard let writer = videoWriter, writer.status == .failed else {
+                            guard let writer = self.videoWriter, writer.status == .failed else {
                                 return nil
                             }
                             return writer.error ?? ScreenRecorderError.captureInterrupted
@@ -438,8 +438,8 @@ public final class ScreenRecorder: NSObject {
                 return
             }
 
-            withStateLock {
-                isRecording = false
+            self.withStateLock {
+                self.isRecording = false
             }
             // stop() may arrive before the first sample: settle the pending
             // start so the caller's start promise does not hang.

--- a/ios/Sources/ScreenRecorderPlugin/Wyler.swift
+++ b/ios/Sources/ScreenRecorderPlugin/Wyler.swift
@@ -73,6 +73,7 @@ public final class ScreenRecorder: NSObject {
     private var delegateSessionID: UInt64 = 0
     private var recordingEstablishedSessionID: UInt64 = 0
     private var pendingRestartDrain = false
+    private var restartDrainGeneration: UInt64 = 0
     private let stateLock = NSLock()
 
     private struct FinalizationSnapshot {
@@ -112,6 +113,7 @@ public final class ScreenRecorder: NSObject {
         withStateLock {
             isFinalizing = false
             pendingRestartDrain = true
+            restartDrainGeneration += 1
             recordingEstablishedSessionID = 0
         }
     }
@@ -137,9 +139,14 @@ public final class ScreenRecorder: NSObject {
                                videoFormat: VideoContainerFormat = .mp4,
                                handler: @escaping (Error?) -> Void) {
         if withStateLock({ pendingRestartDrain }) {
+            let drainGeneration = withStateLock { restartDrainGeneration }
             invalidateDelegateSession()
             recorder.stopCapture(handler: { [weak self] _ in
                 guard let self = self else { return }
+                let shouldContinue = withStateLock {
+                    pendingRestartDrain && restartDrainGeneration == drainGeneration
+                }
+                guard shouldContinue else { return }
                 withStateLock {
                     pendingRestartDrain = false
                 }
@@ -272,10 +279,10 @@ public final class ScreenRecorder: NSObject {
         recorder.stopCapture(handler: { [weak self] _ in
             guard let self = self else { return }
             self.invalidateDelegateSession()
+            guard self.isActiveCaptureSession(sessionID) else { return }
             withStateLock {
                 pendingRestartDrain = false
             }
-            guard self.isActiveCaptureSession(sessionID) else { return }
             withStateLock {
                 delegateSessionID = sessionID
             }

--- a/ios/Sources/ScreenRecorderPlugin/Wyler.swift
+++ b/ios/Sources/ScreenRecorderPlugin/Wyler.swift
@@ -70,6 +70,7 @@ public final class ScreenRecorder: NSObject {
     private var videoWritingStarted = false
     private var isFinalizing = false
     private var captureSessionID: UInt64 = 0
+    private var delegateSessionID: UInt64 = 0
     private let stateLock = NSLock()
 
     private struct FinalizationSnapshot {
@@ -92,6 +93,23 @@ public final class ScreenRecorder: NSObject {
         return withStateLock {
             sessionID == captureSessionID && isRecording && !isFinalizing
         }
+    }
+
+    private func isActiveDelegateSession() -> Bool {
+        return withStateLock {
+            delegateSessionID != 0 &&
+                delegateSessionID == captureSessionID &&
+                isRecording &&
+                !isFinalizing &&
+                !stopRequested
+        }
+    }
+
+    private func invalidateDelegateSession() {
+        withStateLock {
+            delegateSessionID = 0
+        }
+        recorder.delegate = nil
     }
 
     private func nextCaptureSessionID() -> UInt64 {
@@ -223,7 +241,12 @@ public final class ScreenRecorder: NSObject {
         }
         recorder.stopCapture(handler: { [weak self] _ in
             guard let self = self else { return }
+            self.invalidateDelegateSession()
             guard self.isActiveCaptureSession(sessionID) else { return }
+            withStateLock {
+                delegateSessionID = sessionID
+            }
+            self.recorder.delegate = self
             self.recorder.startCapture(handler: { [weak self] (sampleBuffer, sampleType, passedError) in
                 guard let self = self else { return }
                 guard self.isActiveCaptureSession(sessionID) else { return }
@@ -332,6 +355,7 @@ public final class ScreenRecorder: NSObject {
             stopRequested = true
             isFinalizing = true
             captureSessionID += 1
+            delegateSessionID = 0
             return FinalizationSnapshot(
                 outputURL: videoOutputURL,
                 writer: videoWriter,
@@ -346,6 +370,7 @@ public final class ScreenRecorder: NSObject {
             handler(nil)
             return
         }
+        invalidateDelegateSession()
         recorder.stopCapture(handler: { error in
             if let error = error {
                 self.settlePendingStart(error)
@@ -450,6 +475,7 @@ public final class ScreenRecorder: NSObject {
             isRecording = false
             isFinalizing = true
             captureSessionID += 1
+            delegateSessionID = 0
             return FinalizationSnapshot(
                 outputURL: videoOutputURL,
                 writer: videoWriter,
@@ -461,6 +487,7 @@ public final class ScreenRecorder: NSObject {
             )
         }
         guard let snapshot else { return }
+        invalidateDelegateSession()
         finishWriterAndDeliver(snapshot: snapshot, handler: { finishError in
             let url = snapshot.hasVideoContent ? snapshot.outputURL : nil
             self.onExternalStop?(url, error ?? finishError)
@@ -504,10 +531,12 @@ extension ScreenRecorder: RPScreenRecorderDelegate {
         didStopRecordingWithError error: Error,
         previewViewController _: RPPreviewViewController?
     ) {
+        guard isActiveDelegateSession() else { return }
         // A stop before the first sample fails the still-pending start; only
         // a capture that was actually running is an external stop.
         if !settlePendingStart(error) {
             handleRecordingEndedExternally(error: error)
         }
+        invalidateDelegateSession()
     }
 }

--- a/ios/Sources/ScreenRecorderPlugin/Wyler.swift
+++ b/ios/Sources/ScreenRecorderPlugin/Wyler.swift
@@ -163,6 +163,9 @@ public final class ScreenRecorder: NSObject {
         recorder.startCapture(handler: { (sampleBuffer, sampleType, passedError) in
             if let passedError = passedError {
                 if !sent {
+                    // The capture never started — clear the flag so a later
+                    // delegate callback cannot report this as an external stop.
+                    self.isRecording = false
                     handler(passedError)
                     sent = true
                 }
@@ -210,6 +213,7 @@ public final class ScreenRecorder: NSObject {
 
     public func stoprecording(handler: @escaping (Error?) -> Void) {
         stopRequested = true
+        let outputURL = videoOutputURL
         recorder.stopCapture(handler: { error in
             if let error = error {
                 handler(error)
@@ -217,11 +221,11 @@ public final class ScreenRecorder: NSObject {
             }
 
             self.isRecording = false
-            self.finishWriterAndDeliver(handler: handler)
+            self.finishWriterAndDeliver(outputURL: outputURL, handler: handler)
         })
     }
 
-    private func finishWriterAndDeliver(handler: @escaping (Error?) -> Void) {
+    private func finishWriterAndDeliver(outputURL: URL?, handler: @escaping (Error?) -> Void) {
         videoWriterInput?.markAsFinished()
         micAudioWriterInput?.markAsFinished()
         appAudioWriterInput?.markAsFinished()
@@ -237,18 +241,18 @@ public final class ScreenRecorder: NSObject {
                     handler(finishError)
                     return
                 }
-                self.deliverOutput(handler: handler)
+                self.deliverOutput(url: outputURL, handler: handler)
             }
         } else if writer.status == .failed {
             handler(writer.error)
         } else {
-            self.deliverOutput(handler: handler)
+            self.deliverOutput(url: outputURL, handler: handler)
         }
     }
 
-    private func deliverOutput(handler: @escaping (Error?) -> Void) {
+    private func deliverOutput(url: URL?, handler: @escaping (Error?) -> Void) {
         if saveToCameraRoll {
-            saveVideoToCameraRollAfterAuthorized(handler: handler)
+            saveVideoToCameraRollAfterAuthorized(url: url, handler: handler)
         } else {
             handler(nil)
         }
@@ -257,19 +261,23 @@ public final class ScreenRecorder: NSObject {
     private func handleRecordingEndedExternally(error: Error?) {
         guard isRecording, !stopRequested else { return }
         isRecording = false
-        finishWriterAndDeliver(handler: { [weak self] finishError in
+        // Capture the session's output URL: finishWriting is asynchronous and
+        // a new startRecording() would otherwise republish the next
+        // recording's URL (and save its file to the camera roll).
+        let outputURL = videoOutputURL
+        finishWriterAndDeliver(outputURL: outputURL, handler: { [weak self] finishError in
             guard let self = self else { return }
-            self.onExternalStop?(self.videoOutputURL, error ?? finishError)
+            self.onExternalStop?(outputURL, error ?? finishError)
         })
     }
 
-    private func saveVideoToCameraRollAfterAuthorized(handler: @escaping (Error?) -> Void) {
+    private func saveVideoToCameraRollAfterAuthorized(url: URL?, handler: @escaping (Error?) -> Void) {
         if PHPhotoLibrary.authorizationStatus() == .authorized {
-            self.saveVideoToCameraRoll(handler: handler)
+            self.saveVideoToCameraRoll(url: url, handler: handler)
         } else {
             PHPhotoLibrary.requestAuthorization({ (status) in
                 if status == .authorized {
-                    self.saveVideoToCameraRoll(handler: handler)
+                    self.saveVideoToCameraRoll(url: url, handler: handler)
                 } else {
                     handler(ScreenRecorderError.photoLibraryAccessNotGranted)
                 }
@@ -277,13 +285,13 @@ public final class ScreenRecorder: NSObject {
         }
     }
 
-    private func saveVideoToCameraRoll(handler: @escaping (Error?) -> Void) {
-        guard let videoOutputURL = self.videoOutputURL else {
+    private func saveVideoToCameraRoll(url: URL?, handler: @escaping (Error?) -> Void) {
+        guard let url = url else {
             return handler(nil)
         }
 
         PHPhotoLibrary.shared().performChanges({
-            PHAssetChangeRequest.creationRequestForAssetFromVideo(atFileURL: videoOutputURL)
+            PHAssetChangeRequest.creationRequestForAssetFromVideo(atFileURL: url)
         }, completionHandler: { _, error in
             if let error = error {
                 handler(error)

--- a/ios/Sources/ScreenRecorderPlugin/Wyler.swift
+++ b/ios/Sources/ScreenRecorderPlugin/Wyler.swift
@@ -223,10 +223,12 @@ public final class ScreenRecorder: NSObject {
         if self.videoWriter?.status == AVAssetWriter.Status.unknown {
             self.videoWriter?.startWriting()
             self.videoWriter?.startSession(atSourceTime: CMSampleBufferGetPresentationTimeStamp(sampleBuffer))
+        }
+        if self.videoWriter?.status == AVAssetWriter.Status.writing {
             videoWritingStarted = true
-        } else if self.videoWriter?.status == AVAssetWriter.Status.writing &&
-                    self.videoWriterInput?.isReadyForMoreMediaData == true {
-            self.videoWriterInput?.append(sampleBuffer)
+            if self.videoWriterInput?.isReadyForMoreMediaData == true {
+                self.videoWriterInput?.append(sampleBuffer)
+            }
         }
     }
 
@@ -241,6 +243,7 @@ public final class ScreenRecorder: NSObject {
     public func stoprecording(handler: @escaping (Error?) -> Void) {
         stopRequested = true
         let outputURL = videoOutputURL
+        let hadVideoContent = videoWritingStarted
         recorder.stopCapture(handler: { error in
             if let error = error {
                 self.settlePendingStart(error)
@@ -252,11 +255,19 @@ public final class ScreenRecorder: NSObject {
             // stop() may arrive before the first sample: settle the pending
             // start so the caller's start promise does not hang.
             self.settlePendingStart(ScreenRecorderError.captureInterrupted)
-            self.finishWriterAndDeliver(outputURL: outputURL, handler: handler)
+            self.finishWriterAndDeliver(
+                outputURL: outputURL,
+                hasVideoContent: hadVideoContent,
+                handler: handler
+            )
         })
     }
 
-    private func finishWriterAndDeliver(outputURL: URL?, handler: @escaping (Error?) -> Void) {
+    private func finishWriterAndDeliver(
+        outputURL: URL?,
+        hasVideoContent: Bool,
+        handler: @escaping (Error?) -> Void
+    ) {
         videoWriterInput?.markAsFinished()
         micAudioWriterInput?.markAsFinished()
         appAudioWriterInput?.markAsFinished()
@@ -272,17 +283,21 @@ public final class ScreenRecorder: NSObject {
                     handler(finishError)
                     return
                 }
-                self.deliverOutput(url: outputURL, handler: handler)
+                self.deliverOutput(url: outputURL, hasVideoContent: hasVideoContent, handler: handler)
             }
         } else if writer.status == .failed {
             handler(writer.error)
         } else {
-            self.deliverOutput(url: outputURL, handler: handler)
+            self.deliverOutput(url: outputURL, hasVideoContent: hasVideoContent, handler: handler)
         }
     }
 
-    private func deliverOutput(url: URL?, handler: @escaping (Error?) -> Void) {
-        guard videoWritingStarted else {
+    private func deliverOutput(
+        url: URL?,
+        hasVideoContent: Bool,
+        handler: @escaping (Error?) -> Void
+    ) {
+        guard hasVideoContent else {
             handler(nil)
             return
         }
@@ -300,11 +315,15 @@ public final class ScreenRecorder: NSObject {
         // a new startRecording() would otherwise republish the next
         // recording's URL (and save its file to the camera roll).
         let outputURL = videoOutputURL
-        finishWriterAndDeliver(outputURL: outputURL, handler: { [weak self] finishError in
-            guard let self = self else { return }
-            let url = self.videoWritingStarted ? outputURL : nil
-            self.onExternalStop?(url, error ?? finishError)
-        })
+        let hadVideoContent = videoWritingStarted
+        finishWriterAndDeliver(
+            outputURL: outputURL,
+            hasVideoContent: hadVideoContent,
+            handler: { finishError in
+                let url = hadVideoContent ? outputURL : nil
+                self.onExternalStop?(url, error ?? finishError)
+            }
+        )
     }
 
     private func saveVideoToCameraRollAfterAuthorized(url: URL?, handler: @escaping (Error?) -> Void) {

--- a/ios/Sources/ScreenRecorderPlugin/Wyler.swift
+++ b/ios/Sources/ScreenRecorderPlugin/Wyler.swift
@@ -71,6 +71,8 @@ public final class ScreenRecorder: NSObject {
     private var isFinalizing = false
     private var captureSessionID: UInt64 = 0
     private var delegateSessionID: UInt64 = 0
+    private var recordingEstablishedSessionID: UInt64 = 0
+    private var pendingRestartDrain = false
     private let stateLock = NSLock()
 
     private struct FinalizationSnapshot {
@@ -97,11 +99,20 @@ public final class ScreenRecorder: NSObject {
 
     private func isActiveDelegateSession() -> Bool {
         return withStateLock {
-            delegateSessionID != 0 &&
+            !pendingRestartDrain &&
+                delegateSessionID != 0 &&
                 delegateSessionID == captureSessionID &&
                 isRecording &&
                 !isFinalizing &&
                 !stopRequested
+        }
+    }
+
+    private func markFinalizationComplete() {
+        withStateLock {
+            isFinalizing = false
+            pendingRestartDrain = true
+            recordingEstablishedSessionID = 0
         }
     }
 
@@ -125,6 +136,24 @@ public final class ScreenRecorder: NSObject {
                                recordAudio: Bool = false,
                                videoFormat: VideoContainerFormat = .mp4,
                                handler: @escaping (Error?) -> Void) {
+        if withStateLock({ pendingRestartDrain }) {
+            invalidateDelegateSession()
+            recorder.stopCapture(handler: { [weak self] _ in
+                guard let self = self else { return }
+                withStateLock {
+                    pendingRestartDrain = false
+                }
+                self.startRecording(
+                    to: outputURL,
+                    size: size,
+                    saveToCameraRoll: saveToCameraRoll,
+                    recordAudio: recordAudio,
+                    videoFormat: videoFormat,
+                    handler: handler
+                )
+            })
+            return
+        }
         // Reject before any writer/session state is touched: a second start
         // while the first is still pending must not disturb the first capture.
         let rejectError: Error? = withStateLock {
@@ -174,6 +203,7 @@ public final class ScreenRecorder: NSObject {
         micAudioWriterInput = nil
         appAudioWriterInput = nil
         videoWritingStarted = false
+        recordingEstablishedSessionID = 0
     }
 
     private func configureAudioSession() throws {
@@ -242,6 +272,9 @@ public final class ScreenRecorder: NSObject {
         recorder.stopCapture(handler: { [weak self] _ in
             guard let self = self else { return }
             self.invalidateDelegateSession()
+            withStateLock {
+                pendingRestartDrain = false
+            }
             guard self.isActiveCaptureSession(sessionID) else { return }
             withStateLock {
                 delegateSessionID = sessionID
@@ -332,6 +365,7 @@ public final class ScreenRecorder: NSObject {
                 return false
             }
             videoWritingStarted = true
+            recordingEstablishedSessionID = captureSessionID
             if videoWriterInput?.isReadyForMoreMediaData == true {
                 videoWriterInput?.append(sampleBuffer)
             }
@@ -404,9 +438,7 @@ public final class ScreenRecorder: NSObject {
         appInput?.markAsFinished()
 
         guard let writer = writer else {
-            withStateLock {
-                isFinalizing = false
-            }
+            self.markFinalizationComplete()
             handler(nil)
             return
         }
@@ -414,9 +446,7 @@ public final class ScreenRecorder: NSObject {
         if writer.status == .writing {
             writer.finishWriting {
                 if let finishError = writer.error {
-                    withStateLock {
-                        isFinalizing = false
-                    }
+                    self.markFinalizationComplete()
                     handler(finishError)
                     return
                 }
@@ -425,27 +455,21 @@ public final class ScreenRecorder: NSObject {
                     hasVideoContent: snapshot.hasVideoContent,
                     saveToCameraRoll: snapshot.saveToCameraRoll,
                     handler: { error in
-                        withStateLock {
-                            isFinalizing = false
-                        }
+                        self.markFinalizationComplete()
                         handler(error)
                     }
                 )
             }
         } else if writer.status == .failed {
-            withStateLock {
-                isFinalizing = false
-            }
+            self.markFinalizationComplete()
             handler(writer.error)
         } else {
-            deliverOutput(
+            self.deliverOutput(
                 url: snapshot.outputURL,
                 hasVideoContent: snapshot.hasVideoContent,
                 saveToCameraRoll: snapshot.saveToCameraRoll,
                 handler: { error in
-                    withStateLock {
-                        isFinalizing = false
-                    }
+                    self.markFinalizationComplete()
                     handler(error)
                 }
             )
@@ -534,9 +558,19 @@ extension ScreenRecorder: RPScreenRecorderDelegate {
         guard isActiveDelegateSession() else { return }
         // A stop before the first sample fails the still-pending start; only
         // a capture that was actually running is an external stop.
-        if !settlePendingStart(error) {
-            handleRecordingEndedExternally(error: error)
+        if settlePendingStart(error) {
+            invalidateDelegateSession()
+            return
         }
+        let shouldFinalize = withStateLock {
+            recordingEstablishedSessionID != 0 &&
+                recordingEstablishedSessionID == captureSessionID
+        }
+        guard shouldFinalize else {
+            invalidateDelegateSession()
+            return
+        }
+        handleRecordingEndedExternally(error: error)
         invalidateDelegateSession()
     }
 }

--- a/ios/Sources/ScreenRecorderPlugin/Wyler.swift
+++ b/ios/Sources/ScreenRecorderPlugin/Wyler.swift
@@ -69,6 +69,13 @@ public final class ScreenRecorder: NSObject {
     private var pendingStartHandler: ((Error?) -> Void)?
     private var videoWritingStarted = false
     private var isFinalizing = false
+    private let stateLock = NSLock()
+
+    private func withStateLock<T>(_ body: () throws -> T) rethrows -> T {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        return try body()
+    }
 
     public func startRecording(to outputURL: URL? = nil,
                                size: CGSize? = nil,
@@ -78,14 +85,20 @@ public final class ScreenRecorder: NSObject {
                                handler: @escaping (Error?) -> Void) {
         // Reject before any writer/session state is touched: a second start
         // while the first is still pending must not disturb the first capture.
-        guard pendingStartHandler == nil, !isFinalizing else {
-            return handler(ScreenRecorderError.captureAlreadyPending)
+        let rejectError: Error? = withStateLock {
+            guard pendingStartHandler == nil, !isFinalizing else {
+                return ScreenRecorderError.captureAlreadyPending
+            }
+            stopRequested = false
+            return nil
+        }
+        if let rejectError {
+            return handler(rejectError)
         }
         self.saveToCameraRoll = saveToCameraRoll
         self.recordAudio = recordAudio
         self.videoFormat = videoFormat
         resetWriterState()
-        stopRequested = false
         recorder.delegate = self
 
         recorder.isMicrophoneEnabled = recordAudio
@@ -111,7 +124,9 @@ public final class ScreenRecorder: NSObject {
         videoWriterInput = nil
         micAudioWriterInput = nil
         appAudioWriterInput = nil
-        videoWritingStarted = false
+        withStateLock {
+            videoWritingStarted = false
+        }
     }
 
     private func configureAudioSession() throws {
@@ -169,11 +184,13 @@ public final class ScreenRecorder: NSObject {
         guard recorder.isAvailable else {
             return handler(ScreenRecorderError.notAvailable)
         }
-        isRecording = true
-        // The start is settled exactly once — by the first sample, a capture
-        // failure, the delegate, or stoprecording() — whichever comes first,
-        // so the plugin's start promise never hangs and never settles twice.
-        pendingStartHandler = handler
+        withStateLock {
+            isRecording = true
+            // The start is settled exactly once — by the first sample, a capture
+            // failure, the delegate, or stoprecording() — whichever comes first,
+            // so the plugin's start promise never hangs and never settles twice.
+            pendingStartHandler = handler
+        }
         recorder.startCapture(handler: { [weak self] (sampleBuffer, sampleType, passedError) in
             guard let self = self else { return }
             if let passedError = passedError {
@@ -215,12 +232,18 @@ public final class ScreenRecorder: NSObject {
     /// to the delegate / stoprecording().
     @discardableResult
     private func settlePendingStart(_ error: Error?) -> Bool {
-        guard let startHandler = pendingStartHandler else {
-            return false
+        let startHandler: ((Error?) -> Void)? = withStateLock {
+            guard let handler = pendingStartHandler else {
+                return nil
+            }
+            pendingStartHandler = nil
+            if error != nil {
+                isRecording = false
+            }
+            return handler
         }
-        pendingStartHandler = nil
-        if error != nil {
-            isRecording = false
+        guard let startHandler else {
+            return false
         }
         startHandler(error)
         return true
@@ -242,7 +265,9 @@ public final class ScreenRecorder: NSObject {
         guard writer.status == AVAssetWriter.Status.writing else {
             return false
         }
-        videoWritingStarted = true
+        withStateLock {
+            videoWritingStarted = true
+        }
         if videoWriterInput?.isReadyForMoreMediaData == true {
             videoWriterInput?.append(sampleBuffer)
         }
@@ -258,10 +283,13 @@ public final class ScreenRecorder: NSObject {
     }
 
     public func stoprecording(handler: @escaping (Error?) -> Void) {
-        stopRequested = true
-        let outputURL = videoOutputURL
-        let hadVideoContent = videoWritingStarted
-        let saveToCameraRoll = saveToCameraRoll
+        let snapshots: (URL?, Bool, Bool) = withStateLock {
+            stopRequested = true
+            return (videoOutputURL, videoWritingStarted, saveToCameraRoll)
+        }
+        let outputURL = snapshots.0
+        let hadVideoContent = snapshots.1
+        let saveToCameraRoll = snapshots.2
         recorder.stopCapture(handler: { error in
             if let error = error {
                 self.settlePendingStart(error)
@@ -269,7 +297,9 @@ public final class ScreenRecorder: NSObject {
                 return
             }
 
-            self.isRecording = false
+            withStateLock {
+                isRecording = false
+            }
             // stop() may arrive before the first sample: settle the pending
             // start so the caller's start promise does not hang.
             self.settlePendingStart(ScreenRecorderError.captureInterrupted)
@@ -288,7 +318,9 @@ public final class ScreenRecorder: NSObject {
         saveToCameraRoll: Bool,
         handler: @escaping (Error?) -> Void
     ) {
-        isFinalizing = true
+        withStateLock {
+            isFinalizing = true
+        }
         let writer = videoWriter
         let videoInput = videoWriterInput
         let micInput = micAudioWriterInput
@@ -299,7 +331,9 @@ public final class ScreenRecorder: NSObject {
         appInput?.markAsFinished()
 
         guard let writer = writer else {
-            isFinalizing = false
+            withStateLock {
+                isFinalizing = false
+            }
             handler(nil)
             return
         }
@@ -307,7 +341,9 @@ public final class ScreenRecorder: NSObject {
         if writer.status == .writing {
             writer.finishWriting {
                 if let finishError = writer.error {
-                    self.isFinalizing = false
+                    withStateLock {
+                        isFinalizing = false
+                    }
                     handler(finishError)
                     return
                 }
@@ -316,13 +352,17 @@ public final class ScreenRecorder: NSObject {
                     hasVideoContent: hasVideoContent,
                     saveToCameraRoll: saveToCameraRoll,
                     handler: { error in
-                        self.isFinalizing = false
+                        withStateLock {
+                            isFinalizing = false
+                        }
                         handler(error)
                     }
                 )
             }
         } else if writer.status == .failed {
-            isFinalizing = false
+            withStateLock {
+                isFinalizing = false
+            }
             handler(writer.error)
         } else {
             deliverOutput(
@@ -330,7 +370,9 @@ public final class ScreenRecorder: NSObject {
                 hasVideoContent: hasVideoContent,
                 saveToCameraRoll: saveToCameraRoll,
                 handler: { error in
-                    self.isFinalizing = false
+                    withStateLock {
+                        isFinalizing = false
+                    }
                     handler(error)
                 }
             )
@@ -355,14 +397,15 @@ public final class ScreenRecorder: NSObject {
     }
 
     private func handleRecordingEndedExternally(error: Error?) {
-        guard isRecording, !stopRequested else { return }
-        isRecording = false
-        // Capture the session's output URL: finishWriting is asynchronous and
-        // a new startRecording() would otherwise republish the next
-        // recording's URL (and save its file to the camera roll).
-        let outputURL = videoOutputURL
-        let hadVideoContent = videoWritingStarted
-        let saveToCameraRoll = saveToCameraRoll
+        let session: (URL?, Bool, Bool)? = withStateLock {
+            guard isRecording, !stopRequested else { return nil }
+            isRecording = false
+            return (videoOutputURL, videoWritingStarted, saveToCameraRoll)
+        }
+        guard let session else { return }
+        let outputURL = session.0
+        let hadVideoContent = session.1
+        let saveToCameraRoll = session.2
         finishWriterAndDeliver(
             outputURL: outputURL,
             hasVideoContent: hadVideoContent,

--- a/ios/Sources/ScreenRecorderPlugin/Wyler.swift
+++ b/ios/Sources/ScreenRecorderPlugin/Wyler.swift
@@ -69,6 +69,7 @@ public final class ScreenRecorder: NSObject {
     private var pendingStartHandler: ((Error?) -> Void)?
     private var videoWritingStarted = false
     private var isFinalizing = false
+    private var captureSessionID: UInt64 = 0
     private let stateLock = NSLock()
 
     private struct FinalizationSnapshot {
@@ -85,6 +86,19 @@ public final class ScreenRecorder: NSObject {
         stateLock.lock()
         defer { stateLock.unlock() }
         return try body()
+    }
+
+    private func isActiveCaptureSession(_ sessionID: UInt64) -> Bool {
+        return withStateLock {
+            sessionID == captureSessionID && isRecording && !isFinalizing
+        }
+    }
+
+    private func nextCaptureSessionID() -> UInt64 {
+        return withStateLock {
+            captureSessionID += 1
+            return captureSessionID
+        }
     }
 
     public func startRecording(to outputURL: URL? = nil,
@@ -127,6 +141,11 @@ public final class ScreenRecorder: NSObject {
             }
             startCapture(handler: handler)
         } catch let err {
+            withStateLock {
+                isRecording = false
+                pendingStartHandler = nil
+                captureSessionID += 1
+            }
             handler(err)
         }
     }
@@ -194,6 +213,7 @@ public final class ScreenRecorder: NSObject {
         guard recorder.isAvailable else {
             return handler(ScreenRecorderError.notAvailable)
         }
+        let sessionID = nextCaptureSessionID()
         withStateLock {
             isRecording = true
             // The start is settled exactly once — by the first sample, a capture
@@ -201,45 +221,50 @@ public final class ScreenRecorder: NSObject {
             // so the plugin's start promise never hangs and never settles twice.
             pendingStartHandler = handler
         }
-        recorder.startCapture(handler: { [weak self] (sampleBuffer, sampleType, passedError) in
+        recorder.stopCapture(handler: { [weak self] _ in
             guard let self = self else { return }
-            if let passedError = passedError {
-                // Fails a still-pending start; once the start is settled the
-                // delegate owns the end-of-capture reporting.
-                if !self.settlePendingStart(passedError) {
-                    self.handleRecordingEndedExternally(error: passedError)
+            guard self.isActiveCaptureSession(sessionID) else { return }
+            self.recorder.startCapture(handler: { [weak self] (sampleBuffer, sampleType, passedError) in
+                guard let self = self else { return }
+                guard self.isActiveCaptureSession(sessionID) else { return }
+                if let passedError = passedError {
+                    // Fails a still-pending start; once the start is settled the
+                    // delegate owns the end-of-capture reporting.
+                    if !self.settlePendingStart(passedError) {
+                        self.handleRecordingEndedExternally(error: passedError)
+                    }
+                    return
                 }
-                return
-            }
 
-            switch sampleType {
-            case .video:
-                if self.handleSampleBuffer(sampleBuffer: sampleBuffer) {
-                    self.settlePendingStart(nil)
-                } else {
-                    let error: Error? = self.withStateLock {
-                        guard let writer = videoWriter, writer.status == .failed else {
-                            return nil
+                switch sampleType {
+                case .video:
+                    if self.handleSampleBuffer(sampleBuffer: sampleBuffer) {
+                        self.settlePendingStart(nil)
+                    } else {
+                        let error: Error? = self.withStateLock {
+                            guard let writer = videoWriter, writer.status == .failed else {
+                                return nil
+                            }
+                            return writer.error ?? ScreenRecorderError.captureInterrupted
                         }
-                        return writer.error ?? ScreenRecorderError.captureInterrupted
-                    }
-                    if let error = error {
-                        if !self.settlePendingStart(error) {
-                            self.handleRecordingEndedExternally(error: error)
+                        if let error = error {
+                            if !self.settlePendingStart(error) {
+                                self.handleRecordingEndedExternally(error: error)
+                            }
                         }
                     }
+                case .audioApp:
+                    if self.recordAudio {
+                        self.add(sample: sampleBuffer, to: self.appAudioWriterInput)
+                    }
+                case .audioMic:
+                    if self.recordAudio {
+                        self.add(sample: sampleBuffer, to: self.micAudioWriterInput)
+                    }
+                default:
+                    break
                 }
-            case .audioApp:
-                if self.recordAudio {
-                    self.add(sample: sampleBuffer, to: self.appAudioWriterInput)
-                }
-            case .audioMic:
-                if self.recordAudio {
-                    self.add(sample: sampleBuffer, to: self.micAudioWriterInput)
-                }
-            default:
-                break
-            }
+            })
         })
     }
 
@@ -306,6 +331,7 @@ public final class ScreenRecorder: NSObject {
             guard !isFinalizing else { return nil }
             stopRequested = true
             isFinalizing = true
+            captureSessionID += 1
             return FinalizationSnapshot(
                 outputURL: videoOutputURL,
                 writer: videoWriter,
@@ -423,6 +449,7 @@ public final class ScreenRecorder: NSObject {
             guard isRecording, !stopRequested else { return nil }
             isRecording = false
             isFinalizing = true
+            captureSessionID += 1
             return FinalizationSnapshot(
                 outputURL: videoOutputURL,
                 writer: videoWriter,

--- a/ios/Sources/ScreenRecorderPlugin/Wyler.swift
+++ b/ios/Sources/ScreenRecorderPlugin/Wyler.swift
@@ -303,9 +303,11 @@ public final class ScreenRecorder: NSObject {
 }
 
 extension ScreenRecorder: RPScreenRecorderDelegate {
-    public func screenRecorder(_ screenRecorder: RPScreenRecorder,
-                               didStopRecordingWithError error: Error,
-                               previewViewController: RPPreviewViewController?) {
+    public func screenRecorder(
+        _: RPScreenRecorder,
+        didStopRecordingWithError error: Error,
+        previewViewController _: RPPreviewViewController?
+    ) {
         handleRecordingEndedExternally(error: error)
     }
 }

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -1,3 +1,5 @@
+import type { PluginListenerHandle } from '@capacitor/core';
+
 /**
  * Supported video container formats for screen recordings.
  *
@@ -30,6 +32,33 @@ export interface StartRecordingOptions {
    * @example 'mov'
    */
   format?: ScreenRecorderVideoFormat | 'video/mp4' | 'video/quicktime';
+}
+
+/**
+ * Payload for the `onStopped` event.
+ *
+ * Fired when a recording ends without {@link ScreenRecorderPlugin.stop} being
+ * called — the user stopped the capture from the system UI (Android
+ * "Stop sharing") or the recorder terminated itself (max duration / max file
+ * size).
+ *
+ * @since 8.4.0
+ */
+export interface ScreenRecorderStoppedEvent {
+  /**
+   * Local URI of the finished recording (`file://` on Android). Empty string
+   * when the file path could not be resolved.
+   *
+   * @since 8.4.0
+   */
+  url: string;
+
+  /**
+   * Error message when the recording ended with a failure.
+   *
+   * @since 8.4.0
+   */
+  error?: string;
 }
 
 /**
@@ -84,6 +113,34 @@ export interface ScreenRecorderPlugin {
    * ```
    */
   stop(): Promise<void>;
+
+  /**
+   * Listen for recordings that ended without {@link stop} being called —
+   * the user stopped the capture from the system UI (Android "Stop sharing")
+   * or the recorder terminated itself (max duration / max file size).
+   *
+   * @param eventName - `onStopped`
+   * @param listenerFunc - Called with the local URI of the finished file and
+   * the error message when the recording ended with a failure.
+   * @since 8.4.0
+   * @example
+   * ```typescript
+   * ScreenRecorder.addListener('onStopped', (event) => {
+   *   console.log('Recording ended externally:', event.url, event.error);
+   * });
+   * ```
+   */
+  addListener(
+    eventName: 'onStopped',
+    listenerFunc: (event: ScreenRecorderStoppedEvent) => void,
+  ): Promise<PluginListenerHandle>;
+
+  /**
+   * Remove all listeners registered with {@link addListener}.
+   *
+   * @since 8.4.0
+   */
+  removeAllListeners(): Promise<void>;
 
   /**
    * Get the native Capacitor plugin version.

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -119,6 +119,8 @@ export interface ScreenRecorderPlugin {
    * the user stopped the capture from the system UI (Android "Stop sharing")
    * or the recorder terminated itself (max duration / max file size).
    *
+   * This event is currently only emitted on Android; iOS support is planned.
+   *
    * @param eventName - `onStopped`
    * @param listenerFunc - Called with the local URI of the finished file and
    * the error message when the recording ended with a failure.

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -116,10 +116,9 @@ export interface ScreenRecorderPlugin {
 
   /**
    * Listen for recordings that ended without {@link stop} being called —
-   * the user stopped the capture from the system UI (Android "Stop sharing")
-   * or the recorder terminated itself (max duration / max file size).
-   *
-   * This event is currently only emitted on Android; iOS support is planned.
+   * the user stopped the capture from the system UI (Android "Stop sharing"),
+   * the recorder terminated itself (max duration / max file size), or the
+   * system interrupted the capture (iOS, e.g. an incoming call).
    *
    * @param eventName - `onStopped`
    * @param listenerFunc - Called with the local URI of the finished file and

--- a/src/web.ts
+++ b/src/web.ts
@@ -1,6 +1,7 @@
 import { WebPlugin } from '@capacitor/core';
+import type { PluginListenerHandle } from '@capacitor/core';
 
-import type { ScreenRecorderPlugin, StartRecordingOptions } from './definitions';
+import type { ScreenRecorderPlugin, ScreenRecorderStoppedEvent, StartRecordingOptions } from './definitions';
 
 export class ScreenRecorderWeb extends WebPlugin implements ScreenRecorderPlugin {
   async start(_options?: StartRecordingOptions): Promise<void> {
@@ -8,6 +9,17 @@ export class ScreenRecorderWeb extends WebPlugin implements ScreenRecorderPlugin
   }
   async stop(): Promise<void> {
     throw new Error('Method not implemented.');
+  }
+
+  addListener(
+    eventName: 'onStopped',
+    listenerFunc: (event: ScreenRecorderStoppedEvent) => void,
+  ): Promise<PluginListenerHandle> {
+    return super.addListener(eventName, listenerFunc);
+  }
+
+  async removeAllListeners(): Promise<void> {
+    await super.removeAllListeners();
   }
 
   async getPluginVersion(): Promise<{ version: string }> {


### PR DESCRIPTION
Implements #230
Fixes #229

## What

Adds a non-breaking `onStopped` event that fires when a recording ends **without** the JS `stop()` being involved:

- the user taps **"Stop sharing"** in the system media-projection UI (Android),
- the recorder self-terminates on **max duration / max file size**,
- the recorder service ends with a failure.

```typescript
ScreenRecorder.addListener('onStopped', (event) => {
  // event.url   — local file URI of the finished recording ('' if unknown)
  // event.error — failure message when the recorder terminated itself with an error
});
```

`start()` and `stop()` keep their current contracts. The event fires only when the `STATE_IDLE` broadcast arrives with **no pending `start` call** and **no API-initiated stop** (`stopRequested` flag), and only when a recording session was actually active — so normal `stop()` calls never double-report.

## Implementation

- `CapgoScrCast.kt`: `stopRecording()` marks the stop as API-initiated; the `STATE_IDLE` handler of `recordingStateHandler` notifies `externalStopListener` only for externally-ended sessions; `cleanupSession()` now returns the finished output path
- `CapgoRecorderService.kt`: `MediaProjectionCallback.onStop()` now finalizes the recorder and publishes Idle — previously tapping the system "Stop sharing" control stopped the projection without any `STATE_IDLE` broadcast, so the event never fired and the recording coordinator stayed acquired, blocking subsequent `start()` calls
- `CapgoScrCast.kt` (STATE_IDLE handler): a pending start is now settled even when the session ends **without** an error (e.g. the service is destroyed before recording began) — previously the kept-alive `start()` call leaked and the JS promise hung forever
- `ScreenRecorderPlugin.java`: `load()` wires the listener on both the video and audio recorders → `notifyListeners("onStopped", { url, error? })`
- `Wyler.swift` (`ScreenRecorder`): conforms to `RPScreenRecorderDelegate` — when the system stops the capture (interruption, error) the writer is finalized via a shared `finishWriterAndDeliver()` and `onExternalStop` fires with the finished file URL and the stop reason; `isRecording`/`stopRequested` flags keep the event off for API-initiated stops
- `ScreenRecorderPlugin.swift`: `load()` wires `onExternalStop` → `notifyListeners("onStopped", { url, error? })`
- `src/definitions.ts`: `ScreenRecorderStoppedEvent` type + typed `addListener('onStopped', ...)` overload + `removeAllListeners()`
- `src/web.ts`: listener stubs for web parity
- `README.md`: regenerated via `npm run build` (docgen)

## Verification

- [x] `npm run build` (docgen + tsc + rollup) passes
- [x] `cd android && ./gradlew test build` passes
- [ ] Start recording → tap "Stop sharing" in the system UI → `onStopped` fires with the file URI; a subsequent `start()` works
- [ ] Small max-duration limit → recorder self-terminates → `onStopped` fires
- [ ] Normal `stop()` does **not** emit the event (no double-report)
- [ ] `recordAudio: false` path unaffected
- [ ] iOS: interrupt the capture (e.g. incoming call) → `onStopped` fires with the file URL; normal `stop()` does not emit
- [ ] `adb shell am stopservice ...CapgoRecorderService` right after accepting the consent dialog → `start()` rejects ("Recording stopped before it started") instead of hanging
- [ ] iOS: after a failed `start()`, no `onStopped` fires later; rapidly restarting after an external stop never reports the new recording's URL in the old event

Device-side checks are pending; happy to run them and report back.

Android, iOS and web in this PR. On iOS the event covers system-initiated stops (interruptions, capture errors); the user cannot stop an in-app ReplayKit capture from the system UI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an `onStopped` event for recordings ended by system controls, recorder limits, or interruptions.
  - Events include the completed recording URL and an optional error message.
  - Added support for removing all registered event listeners.
  - External recording stops now finalize sessions and clean up recording state consistently on Android and iOS.
  - Recording interruptions are reported more reliably.

- **Documentation**
  - Documented the stopped-recording event, listener APIs, event fields, and listener handle.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->